### PR TITLE
Improve trait implementations for algebraic hashes

### DIFF
--- a/nimue-pow/Cargo.toml
+++ b/nimue-pow/Cargo.toml
@@ -14,6 +14,7 @@ blake3 = "1.5.4"
 keccak = { version = "0.1.4"}
 bytemuck = "1.17.1"
 rayon = { version = "1.10.0", optional = true }
+rand = "0.8.5"
 
 [features]
 default = ["parallel"]

--- a/nimue-pow/src/blake3.rs
+++ b/nimue-pow/src/blake3.rs
@@ -144,11 +144,12 @@ impl Blake3PoW {
 
 #[test]
 fn test_pow_blake3() {
-    use crate::{ByteIOPattern, ByteReader, ByteWriter, IOPattern, PoWChallenge, PoWIOPattern};
+    use crate::{ByteIOPattern, ByteReader, ByteWriter, PoWChallenge, PoWIOPattern};
+    use nimue::{DefaultHash, IOPattern};
 
     const BITS: f64 = 10.0;
 
-    let iopattern = IOPattern::new("the proof of work lottery 🎰")
+    let iopattern = IOPattern::<DefaultHash>::new("the proof of work lottery 🎰")
         .add_bytes(1, "something")
         .challenge_pow("rolling dices");
 

--- a/nimue-pow/src/keccak.rs
+++ b/nimue-pow/src/keccak.rs
@@ -30,11 +30,12 @@ impl PowStrategy for KeccakPoW {
 
 #[test]
 fn test_pow_keccak() {
-    use crate::{ByteIOPattern, ByteReader, ByteWriter, IOPattern, PoWChallenge, PoWIOPattern};
+    use crate::{ByteIOPattern, ByteReader, ByteWriter, PoWChallenge, PoWIOPattern};
+    use nimue::{DefaultHash, IOPattern};
 
     const BITS: f64 = 10.0;
 
-    let iopattern = IOPattern::new("the proof of work lottery 🎰")
+    let iopattern = IOPattern::<DefaultHash>::new("the proof of work lottery 🎰")
         .add_bytes(1, "something")
         .challenge_pow("rolling dices");
 

--- a/nimue-pow/src/lib.rs
+++ b/nimue-pow/src/lib.rs
@@ -1,7 +1,10 @@
 pub mod blake3;
 pub mod keccak;
 
-use nimue::{Arthur, ByteChallenges, ByteIOPattern, ByteReader, ByteWriter, DuplexHash, IOPattern, Merlin, ProofError, ProofResult, Unit};
+use nimue::{
+    Arthur, ByteChallenges, ByteIOPattern, ByteReader, ByteWriter, DuplexHash, Merlin, ProofError,
+    ProofResult, Unit,
+};
 
 /// [`IOPattern`] for proof-of-work challenges.
 pub trait PoWIOPattern {
@@ -33,7 +36,7 @@ pub trait PoWChallenge {
     fn challenge_pow<S: PowStrategy>(&mut self, bits: f64) -> ProofResult<()>;
 }
 
-impl <H, U, R> PoWChallenge for Merlin<H, U, R>
+impl<H, U, R> PoWChallenge for Merlin<H, U, R>
 where
     U: Unit,
     H: DuplexHash<U>,

--- a/nimue-pow/src/lib.rs
+++ b/nimue-pow/src/lib.rs
@@ -1,10 +1,7 @@
 pub mod blake3;
 pub mod keccak;
 
-use nimue::{
-    Arthur, ByteChallenges, ByteIOPattern, ByteReader, ByteWriter, IOPattern, Merlin, ProofError,
-    ProofResult,
-};
+use nimue::{Arthur, ByteChallenges, ByteIOPattern, ByteReader, ByteWriter, DuplexHash, IOPattern, Merlin, ProofError, ProofResult, Unit};
 
 /// [`IOPattern`] for proof-of-work challenges.
 pub trait PoWIOPattern {
@@ -21,7 +18,10 @@ pub trait PoWIOPattern {
     fn challenge_pow(self, label: &str) -> Self;
 }
 
-impl PoWIOPattern for IOPattern {
+impl<IOPattern> PoWIOPattern for IOPattern
+where
+    IOPattern: ByteIOPattern,
+{
     fn challenge_pow(self, label: &str) -> Self {
         // 16 bytes challenge and 16 bytes nonce (that will be written)
         self.challenge_bytes(32, label).add_bytes(8, "pow-nonce")
@@ -33,9 +33,12 @@ pub trait PoWChallenge {
     fn challenge_pow<S: PowStrategy>(&mut self, bits: f64) -> ProofResult<()>;
 }
 
-impl PoWChallenge for Merlin
+impl <H, U, R> PoWChallenge for Merlin<H, U, R>
 where
-    Merlin: ByteWriter,
+    U: Unit,
+    H: DuplexHash<U>,
+    R: rand::CryptoRng + rand::RngCore,
+    Merlin<H, U, R>: ByteWriter + ByteChallenges,
 {
     fn challenge_pow<S: PowStrategy>(&mut self, bits: f64) -> ProofResult<()> {
         let challenge = self.challenge_bytes()?;
@@ -47,9 +50,11 @@ where
     }
 }
 
-impl<'a> PoWChallenge for Arthur<'a>
+impl<'a, H, U> PoWChallenge for Arthur<'a, H, U>
 where
-    Arthur<'a>: ByteReader,
+    U: Unit,
+    H: DuplexHash<U>,
+    Arthur<'a, H, U>: ByteReader + ByteChallenges,
 {
     fn challenge_pow<S: PowStrategy>(&mut self, bits: f64) -> ProofResult<()> {
         let challenge = self.challenge_bytes()?;

--- a/nimue/src/plugins/ark/common.rs
+++ b/nimue/src/plugins/ark/common.rs
@@ -96,24 +96,26 @@ where
     }
 }
 
-impl<'a, H, C, const N: usize> FieldChallenges<Fp<C,N>> for Arthur<'a, H, Fp<C, N>>
-where
-C: FpConfig<N>,
-H: DuplexHash<Fp<C, N>>,
-{
-    fn fill_challenge_scalars(&mut self, output: &mut [Fp<C, N>]) -> ProofResult<()> {
-        self.fill_challenge_units(output).map_err(ProofError::InvalidIO)
-    }
-}
-
-impl<H, C, R, const N: usize> FieldChallenges<Fp<C,N>> for Merlin<H, Fp<C, N>, R>
+impl<H, C, const N: usize> FieldChallenges<Fp<C, N>> for Arthur<'_, H, Fp<C, N>>
 where
     C: FpConfig<N>,
     H: DuplexHash<Fp<C, N>>,
-    R: CryptoRng + RngCore
 {
     fn fill_challenge_scalars(&mut self, output: &mut [Fp<C, N>]) -> ProofResult<()> {
-        self.fill_challenge_units(output).map_err(ProofError::InvalidIO)
+        self.fill_challenge_units(output)
+            .map_err(ProofError::InvalidIO)
+    }
+}
+
+impl<H, C, R, const N: usize> FieldChallenges<Fp<C, N>> for Merlin<H, Fp<C, N>, R>
+where
+    C: FpConfig<N>,
+    H: DuplexHash<Fp<C, N>>,
+    R: CryptoRng + RngCore,
+{
+    fn fill_challenge_scalars(&mut self, output: &mut [Fp<C, N>]) -> ProofResult<()> {
+        self.fill_challenge_units(output)
+            .map_err(ProofError::InvalidIO)
     }
 }
 
@@ -214,7 +216,7 @@ where
 
 // Field  <-> Bytes interactions:
 
-impl<'a, H, C, const N: usize> BytePublic for Arthur<'a, H, Fp<C, N>>
+impl<H, C, const N: usize> BytePublic for Arthur<'_, H, Fp<C, N>>
 where
     C: FpConfig<N>,
     H: DuplexHash<Fp<C, N>>,
@@ -227,7 +229,7 @@ where
     }
 }
 
-impl<'a, H, R, C, const N: usize> BytePublic for Merlin<H, Fp<C, N>, R>
+impl<H, R, C, const N: usize> BytePublic for Merlin<H, Fp<C, N>, R>
 where
     C: FpConfig<N>,
     H: DuplexHash<Fp<C, N>>,
@@ -241,7 +243,7 @@ where
     }
 }
 
-impl<'a, H, R, C, const N: usize> ByteChallenges for Merlin<H, Fp<C, N>, R>
+impl<H, R, C, const N: usize> ByteChallenges for Merlin<H, Fp<C, N>, R>
 where
     C: FpConfig<N>,
     H: DuplexHash<Fp<C, N>>,
@@ -267,7 +269,7 @@ where
 }
 
 /// XXX. duplicate code
-impl<'a, H, C, const N: usize> ByteChallenges for Arthur<'a, H, Fp<C, N>>
+impl<H, C, const N: usize> ByteChallenges for Arthur<'_, H, Fp<C, N>>
 where
     C: FpConfig<N>,
     H: DuplexHash<Fp<C, N>>,

--- a/nimue/src/plugins/ark/common.rs
+++ b/nimue/src/plugins/ark/common.rs
@@ -78,7 +78,7 @@ where
 impl<F, T> FieldChallenges<F> for T
 where
     F: Field,
-    T: ByteChallenges,
+    T: UnitTranscript<u8>,
 {
     fn fill_challenge_scalars(&mut self, output: &mut [F]) -> ProofResult<()> {
         let base_field_size = bytes_uniform_modp(F::BasePrimeField::MODULUS_BIT_SIZE);
@@ -93,6 +93,27 @@ where
             .expect("Could not convert");
         }
         Ok(())
+    }
+}
+
+impl<'a, H, C, const N: usize> FieldChallenges<Fp<C,N>> for Arthur<'a, H, Fp<C, N>>
+where
+C: FpConfig<N>,
+H: DuplexHash<Fp<C, N>>,
+{
+    fn fill_challenge_scalars(&mut self, output: &mut [Fp<C, N>]) -> ProofResult<()> {
+        self.fill_challenge_units(output).map_err(ProofError::InvalidIO)
+    }
+}
+
+impl<H, C, R, const N: usize> FieldChallenges<Fp<C,N>> for Merlin<H, Fp<C, N>, R>
+where
+    C: FpConfig<N>,
+    H: DuplexHash<Fp<C, N>>,
+    R: CryptoRng + RngCore
+{
+    fn fill_challenge_scalars(&mut self, output: &mut [Fp<C, N>]) -> ProofResult<()> {
+        self.fill_challenge_units(output).map_err(ProofError::InvalidIO)
     }
 }
 
@@ -224,7 +245,7 @@ impl<'a, H, R, C, const N: usize> ByteChallenges for Merlin<H, Fp<C, N>, R>
 where
     C: FpConfig<N>,
     H: DuplexHash<Fp<C, N>>,
-    R: CryptoRng + rand::RngCore,
+    R: CryptoRng + RngCore,
 {
     fn fill_challenge_bytes(&mut self, output: &mut [u8]) -> Result<(), IOPatternError> {
         if output == &[] {

--- a/nimue/src/plugins/ark/writer.rs
+++ b/nimue/src/plugins/ark/writer.rs
@@ -4,7 +4,10 @@ use ark_serialize::CanonicalSerialize;
 use rand::{CryptoRng, RngCore};
 
 use super::{FieldPublic, FieldWriter, GroupPublic, GroupWriter};
-use crate::{Arthur, BytePublic, ByteReader, ByteWriter, DuplexHash, IOPatternError, Merlin, ProofResult, Unit, UnitTranscript};
+use crate::{
+    Arthur, BytePublic, ByteReader, ByteWriter, DuplexHash, IOPatternError, Merlin, ProofResult,
+    Unit, UnitTranscript,
+};
 
 impl<F: Field, H: DuplexHash, R: RngCore + CryptoRng> FieldWriter<F> for Merlin<H, u8, R> {
     fn add_scalars(&mut self, input: &[F]) -> ProofResult<()> {

--- a/nimue/src/plugins/ark/writer.rs
+++ b/nimue/src/plugins/ark/writer.rs
@@ -4,7 +4,7 @@ use ark_serialize::CanonicalSerialize;
 use rand::{CryptoRng, RngCore};
 
 use super::{FieldPublic, FieldWriter, GroupPublic, GroupWriter};
-use crate::{DuplexHash, Merlin, ProofResult, UnitTranscript};
+use crate::{Arthur, BytePublic, ByteReader, ByteWriter, DuplexHash, IOPatternError, Merlin, ProofResult, Unit, UnitTranscript};
 
 impl<F: Field, H: DuplexHash, R: RngCore + CryptoRng> FieldWriter<F> for Merlin<H, u8, R> {
     fn add_scalars(&mut self, input: &[F]) -> ProofResult<()> {
@@ -56,5 +56,29 @@ where
             i.serialize_compressed(&mut self.transcript)?;
         }
         Ok(())
+    }
+}
+
+impl<H, R, C, const N: usize> ByteWriter for Merlin<H, Fp<C, N>, R>
+where
+    H: DuplexHash<Fp<C, N>>,
+    C: FpConfig<N>,
+    R: RngCore + CryptoRng,
+{
+    fn add_bytes(&mut self, input: &[u8]) -> Result<(), IOPatternError> {
+        self.public_bytes(input)?;
+        self.transcript.extend(input);
+        Ok(())
+    }
+}
+
+impl<'a, H, C, const N: usize> ByteReader for Arthur<'a, H, Fp<C, N>>
+where
+    H: DuplexHash<Fp<C, N>>,
+    C: FpConfig<N>,
+{
+    fn fill_next_bytes(&mut self, input: &mut [u8]) -> Result<(), IOPatternError> {
+        u8::read(&mut self.transcript, input)?;
+        self.public_bytes(input)
     }
 }


### PR DESCRIPTION
This fixes a few issues related to missing or wrong trait implementations, that make it impossible to work with algebraic hashes:
1. Makes nimue-pow work with any byte-supporting transcript, not just ones with Unit=u8;
2. Fixes the implementation of `FieldChallenges` to use units whenever possible. Previously even own-field challenges would go through the bytes impl for no apparent reason;
3. Implements `ByteReader` and `ByteWriter` for field-based transcripts.