### PR TITLE
chore: small fix on docs and allow to run exaample

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ while maintaining security is crucial. We offer tools for preprocessing the Tran
 It is vital to avoid providing two different challenges for the same prover message. We do our best to avoid it by tying down the prover randomness to the protocol transcript, without making the proof deterministic.
 
 ## More information
-Check out the [documentation](https://arkworks.rs/nimue/) and some [`examples/`](https://github.com/arkworks-rs/nimue/tree/main/examples).
+Check out the [documentation](https://arkworks.rs/nimue/) and some [`examples/`](https://github.com/arkworks-rs/nimue/tree/main/nimue/examples).
 
 ## Funding
 

--- a/nimue-poseidon/Cargo.toml
+++ b/nimue-poseidon/Cargo.toml
@@ -13,11 +13,16 @@ ark-bn254 = { workspace = true, optional = true }
 
 [dev-dependencies]
 ark-bls12-381 = { workspace = true }
+ark-ec = { workspace = true }
+ark-std = { workspace = true }
+hex = { workspace = true }
+blake2 = { workspace = true }
 
 [features]
 bn254 = ["ark-bn254"]
 solinas = []
 bls12-381 = ["nimue/ark", "dep:ark-bls12-381"]
+ark-bls12-381 = ["nimue/ark", "dep:ark-bls12-381"]
 
 [[example]]
 name = "schnorr_algebraic_hash"


### PR DESCRIPTION
```
cargo run --package nimue-poseidon --example schnorr_algebraic_hash --features "ark-bls12-381, bls12-381"
```

I couldn't able to run example on `nimue-poseidon` fixing this

also small hyperlink fix on main readme