### PR TITLE
feat: remove println in PoseidonSponge::permute

### DIFF
--- a/nimue-poseidon/src/lib.rs
+++ b/nimue-poseidon/src/lib.rs
@@ -113,7 +113,6 @@ where
         for i in 0..full_rounds_over_2 {
             self.apply_ark(&mut state, i);
             self.apply_s_box(&mut state, true);
-            println!("{:?}", state);
             self.apply_mds(&mut state);
         }
 


### PR DESCRIPTION
This pr is for removing the println function in PoseidonSponge::permute.

current, when invoke the poseidon hash, lots of output LOL