### PR TITLE
Small Fp Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,55 +100,32 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be2ede2c0c96fa37d5d3484e8a59fec566c4a52b8c84bf993eaa6c67d7225a4c"
 dependencies = [
- "ark-ec 0.6.0",
- "ark-ff 0.6.0",
- "ark-serialize 0.6.0",
- "ark-std 0.6.0",
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
 ]
 
 [[package]]
 name = "ark-curve25519"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d934c527bc397a2591e85dfabd3a705eaa5eed71be763c7e4b802d62ec41ae3"
+version = "0.6.0"
+source = "git+https://github.com/arkworks-rs/algebra?branch=release%2F0.6.0#bffa52711f225e888c1a91e1ec9fc59f2d9d5c94"
 dependencies = [
- "ark-ec 0.5.0",
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
-]
-
-[[package]]
-name = "ark-ec"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
-dependencies = [
- "ahash",
- "ark-ff 0.5.0",
- "ark-poly 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
- "educe",
- "fnv",
- "hashbrown 0.15.5",
- "itertools 0.13.0",
- "num-bigint",
- "num-integer",
- "num-traits",
- "zeroize",
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
 ]
 
 [[package]]
 name = "ark-ec"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
+source = "git+https://github.com/arkworks-rs/algebra?branch=release%2F0.6.0#bffa52711f225e888c1a91e1ec9fc59f2d9d5c94"
 dependencies = [
  "ahash",
- "ark-ff 0.6.0",
- "ark-poly 0.6.0",
- "ark-serialize 0.6.0",
- "ark-std 0.6.0",
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
  "educe",
  "fnv",
  "hashbrown 0.17.0",
@@ -161,34 +138,13 @@ dependencies = [
 
 [[package]]
 name = "ark-ff"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
-dependencies = [
- "ark-ff-asm 0.5.0",
- "ark-ff-macros 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
- "arrayvec",
- "digest 0.10.7",
- "educe",
- "itertools 0.13.0",
- "num-bigint",
- "num-traits",
- "paste",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+source = "git+https://github.com/arkworks-rs/algebra?branch=release%2F0.6.0#bffa52711f225e888c1a91e1ec9fc59f2d9d5c94"
 dependencies = [
- "ark-ff-asm 0.6.0",
- "ark-ff-macros 0.6.0",
- "ark-serialize 0.6.0",
- "ark-std 0.6.0",
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
  "digest 0.10.7",
  "educe",
  "num-bigint",
@@ -198,19 +154,8 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-asm"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "ark-ff-asm"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
+source = "git+https://github.com/arkworks-rs/algebra?branch=release%2F0.6.0#bffa52711f225e888c1a91e1ec9fc59f2d9d5c94"
 dependencies = [
  "quote",
  "syn",
@@ -218,22 +163,8 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-macros"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
-dependencies = [
- "num-bigint",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "ark-ff-macros"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
+source = "git+https://github.com/arkworks-rs/algebra?branch=release%2F0.6.0#bffa52711f225e888c1a91e1ec9fc59f2d9d5c94"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -248,36 +179,20 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26dbfc18163d3313389ce5d515aa675bb694b8ef64744006c5a2c88439c7133"
 dependencies = [
- "ark-ec 0.6.0",
- "ark-ff 0.6.0",
- "ark-std 0.6.0",
-]
-
-[[package]]
-name = "ark-poly"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
-dependencies = [
- "ahash",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
- "educe",
- "fnv",
- "hashbrown 0.15.5",
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
 ]
 
 [[package]]
 name = "ark-poly"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
+source = "git+https://github.com/arkworks-rs/algebra?branch=release%2F0.6.0#bffa52711f225e888c1a91e1ec9fc59f2d9d5c94"
 dependencies = [
  "ahash",
- "ark-ff 0.6.0",
- "ark-serialize 0.6.0",
- "ark-std 0.6.0",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
  "educe",
  "fnv",
  "hashbrown 0.17.0",
@@ -285,47 +200,31 @@ dependencies = [
 
 [[package]]
 name = "ark-secp256k1"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bd211c48debd3037b48873a7aa22c3aba034e83388aa4124795c9f220b88c7"
+version = "0.6.0"
+source = "git+https://github.com/arkworks-rs/algebra?branch=release%2F0.6.0#bffa52711f225e888c1a91e1ec9fc59f2d9d5c94"
 dependencies = [
- "ark-ec 0.5.0",
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
 ]
 
 [[package]]
 name = "ark-secp256r1"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cf8be5820de567729bfa73a410ddd07cec8ad102d9a4bf61fd6b2e60db264e8"
+version = "0.6.0"
+source = "git+https://github.com/arkworks-rs/algebra?branch=release%2F0.6.0#bffa52711f225e888c1a91e1ec9fc59f2d9d5c94"
 dependencies = [
- "ark-ec 0.5.0",
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
-dependencies = [
- "ark-serialize-derive 0.5.0",
- "ark-std 0.5.0",
- "arrayvec",
- "digest 0.10.7",
- "num-bigint",
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
 ]
 
 [[package]]
 name = "ark-serialize"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+source = "git+https://github.com/arkworks-rs/algebra?branch=release%2F0.6.0#bffa52711f225e888c1a91e1ec9fc59f2d9d5c94"
 dependencies = [
- "ark-serialize-derive 0.6.0",
- "ark-std 0.6.0",
+ "ark-serialize-derive",
+ "ark-std",
  "digest 0.10.7",
  "num-bigint",
  "serde_with",
@@ -333,34 +232,12 @@ dependencies = [
 
 [[package]]
 name = "ark-serialize-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "ark-serialize-derive"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
+source = "git+https://github.com/arkworks-rs/algebra?branch=release%2F0.6.0#bffa52711f225e888c1a91e1ec9fc59f2d9d5c94"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
-dependencies = [
- "num-traits",
- "rand 0.8.6",
 ]
 
 [[package]]
@@ -379,10 +256,10 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64149c07e3d07ee2263e831cf747ecf77c58d90a9cfa2813fc45c39dc5c92964"
 dependencies = [
- "ark-ec 0.6.0",
- "ark-ff 0.6.0",
+ "ark-ec",
+ "ark-ff",
  "ark-pallas",
- "ark-std 0.6.0",
+ "ark-std",
 ]
 
 [[package]]
@@ -1248,7 +1125,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
  "foldhash",
 ]
 
@@ -2011,6 +1887,7 @@ dependencies = [
  "pallas-codec",
  "pallas-crypto",
  "rand 0.8.6",
+ "serde",
  "socket2 0.5.10",
  "thiserror",
  "tokio",
@@ -2749,13 +2626,13 @@ version = "0.6.1"
 dependencies = [
  "ark-bls12-381",
  "ark-curve25519",
- "ark-ec 0.6.0",
- "ark-ff 0.6.0",
+ "ark-ec",
+ "ark-ff",
  "ark-pallas",
  "ark-secp256k1",
  "ark-secp256r1",
- "ark-serialize 0.6.0",
- "ark-std 0.6.0",
+ "ark-serialize",
+ "ark-std",
  "ark-vesta",
  "ascon",
  "blake2 0.11.0-rc.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,8 @@ dependencies = [
 [[package]]
 name = "ark-curve25519"
 version = "0.6.0"
-source = "git+https://github.com/arkworks-rs/algebra?branch=release%2F0.6.0#bffa52711f225e888c1a91e1ec9fc59f2d9d5c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85045ea93c7c789597b5feea38cd72efd72dbe42380d629f69f25692b73f4a6e"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -119,7 +120,8 @@ dependencies = [
 [[package]]
 name = "ark-ec"
 version = "0.6.0"
-source = "git+https://github.com/arkworks-rs/algebra?branch=release%2F0.6.0#bffa52711f225e888c1a91e1ec9fc59f2d9d5c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
 dependencies = [
  "ahash",
  "ark-ff",
@@ -139,7 +141,8 @@ dependencies = [
 [[package]]
 name = "ark-ff"
 version = "0.6.0"
-source = "git+https://github.com/arkworks-rs/algebra?branch=release%2F0.6.0#bffa52711f225e888c1a91e1ec9fc59f2d9d5c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
 dependencies = [
  "ark-ff-asm",
  "ark-ff-macros",
@@ -155,7 +158,8 @@ dependencies = [
 [[package]]
 name = "ark-ff-asm"
 version = "0.6.0"
-source = "git+https://github.com/arkworks-rs/algebra?branch=release%2F0.6.0#bffa52711f225e888c1a91e1ec9fc59f2d9d5c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
  "syn",
@@ -164,7 +168,8 @@ dependencies = [
 [[package]]
 name = "ark-ff-macros"
 version = "0.6.0"
-source = "git+https://github.com/arkworks-rs/algebra?branch=release%2F0.6.0#bffa52711f225e888c1a91e1ec9fc59f2d9d5c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -187,7 +192,8 @@ dependencies = [
 [[package]]
 name = "ark-poly"
 version = "0.6.0"
-source = "git+https://github.com/arkworks-rs/algebra?branch=release%2F0.6.0#bffa52711f225e888c1a91e1ec9fc59f2d9d5c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
 dependencies = [
  "ahash",
  "ark-ff",
@@ -201,7 +207,8 @@ dependencies = [
 [[package]]
 name = "ark-secp256k1"
 version = "0.6.0"
-source = "git+https://github.com/arkworks-rs/algebra?branch=release%2F0.6.0#bffa52711f225e888c1a91e1ec9fc59f2d9d5c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41b34e9124731f4834db5a8f92ce085a47cd6f006fdb50359ea508d6256341d"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -211,7 +218,8 @@ dependencies = [
 [[package]]
 name = "ark-secp256r1"
 version = "0.6.0"
-source = "git+https://github.com/arkworks-rs/algebra?branch=release%2F0.6.0#bffa52711f225e888c1a91e1ec9fc59f2d9d5c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e7450e67fdd507af9e1b70dbabffe335d425cbcdeb531b8979b3a8e838fd78"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -221,7 +229,8 @@ dependencies = [
 [[package]]
 name = "ark-serialize"
 version = "0.6.0"
-source = "git+https://github.com/arkworks-rs/algebra?branch=release%2F0.6.0#bffa52711f225e888c1a91e1ec9fc59f2d9d5c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
@@ -233,7 +242,8 @@ dependencies = [
 [[package]]
 name = "ark-serialize-derive"
 version = "0.6.0"
-source = "git+https://github.com/arkworks-rs/algebra?branch=release%2F0.6.0#bffa52711f225e888c1a91e1ec9fc59f2d9d5c94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1057,6 +1067,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,10 +1335,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2583,6 +2613,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3041,9 +3077,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3054,9 +3090,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3064,9 +3100,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3077,9 +3113,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,28 +141,23 @@ dependencies = [
 [[package]]
 name = "ark-ff"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+source = "git+https://github.com/arkworks-rs/algebra#08aa6de11f481f241ab7d6015be6db89eb03e2f1"
 dependencies = [
  "ark-ff-asm",
  "ark-ff-macros",
  "ark-serialize",
  "ark-std",
- "arrayvec",
  "digest 0.10.7",
  "educe",
- "itertools 0.13.0",
  "num-bigint",
  "num-traits",
- "paste",
  "zeroize",
 ]
 
 [[package]]
 name = "ark-ff-asm"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+source = "git+https://github.com/arkworks-rs/algebra#08aa6de11f481f241ab7d6015be6db89eb03e2f1"
 dependencies = [
  "quote",
  "syn",
@@ -171,8 +166,7 @@ dependencies = [
 [[package]]
 name = "ark-ff-macros"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+source = "git+https://github.com/arkworks-rs/algebra#08aa6de11f481f241ab7d6015be6db89eb03e2f1"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -232,21 +226,19 @@ dependencies = [
 [[package]]
 name = "ark-serialize"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+source = "git+https://github.com/arkworks-rs/algebra#08aa6de11f481f241ab7d6015be6db89eb03e2f1"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
- "arrayvec",
  "digest 0.10.7",
  "num-bigint",
+ "serde_with",
 ]
 
 [[package]]
 name = "ark-serialize-derive"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+source = "git+https://github.com/arkworks-rs/algebra#08aa6de11f481f241ab7d6015be6db89eb03e2f1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,14 +96,14 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "ark-bls12-381"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
+checksum = "be2ede2c0c96fa37d5d3484e8a59fec566c4a52b8c84bf993eaa6c67d7225a4c"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
@@ -112,9 +112,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d934c527bc397a2591e85dfabd3a705eaa5eed71be763c7e4b802d62ec41ae3"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
@@ -124,10 +124,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
  "ahash",
- "ark-ff",
- "ark-poly",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
  "educe",
  "fnv",
  "hashbrown 0.15.5",
@@ -139,14 +139,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
+dependencies = [
+ "ahash",
+ "ark-ff 0.6.0",
+ "ark-poly 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.17.0",
+ "itertools 0.14.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff"
 version = "0.5.0"
-source = "git+https://github.com/arkworks-rs/algebra#08aa6de11f481f241ab7d6015be6db89eb03e2f1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
 dependencies = [
- "ark-ff-asm",
- "ark-ff-macros",
- "ark-serialize",
- "ark-std",
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
  "digest 0.10.7",
  "educe",
  "num-bigint",
@@ -157,7 +199,18 @@ dependencies = [
 [[package]]
 name = "ark-ff-asm"
 version = "0.5.0"
-source = "git+https://github.com/arkworks-rs/algebra#08aa6de11f481f241ab7d6015be6db89eb03e2f1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
  "syn",
@@ -166,7 +219,21 @@ dependencies = [
 [[package]]
 name = "ark-ff-macros"
 version = "0.5.0"
-source = "git+https://github.com/arkworks-rs/algebra#08aa6de11f481f241ab7d6015be6db89eb03e2f1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -177,13 +244,13 @@ dependencies = [
 
 [[package]]
 name = "ark-pallas"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c676d42c65f0b2d334fc0ae72a422de2e62ed75beb3022050c0e8a81f6ccc0f"
+checksum = "f26dbfc18163d3313389ce5d515aa675bb694b8ef64744006c5a2c88439c7133"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
@@ -193,12 +260,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
 dependencies = [
  "ahash",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
  "educe",
  "fnv",
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
+dependencies = [
+ "ahash",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -207,9 +289,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bd211c48debd3037b48873a7aa22c3aba034e83388aa4124795c9f220b88c7"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
@@ -218,18 +300,32 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cf8be5820de567729bfa73a410ddd07cec8ad102d9a4bf61fd6b2e60db264e8"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
 name = "ark-serialize"
 version = "0.5.0"
-source = "git+https://github.com/arkworks-rs/algebra#08aa6de11f481f241ab7d6015be6db89eb03e2f1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive",
- "ark-std",
+ "ark-serialize-derive 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive 0.6.0",
+ "ark-std 0.6.0",
  "digest 0.10.7",
  "num-bigint",
  "serde_with",
@@ -238,7 +334,19 @@ dependencies = [
 [[package]]
 name = "ark-serialize-derive"
 version = "0.5.0"
-source = "git+https://github.com/arkworks-rs/algebra#08aa6de11f481f241ab7d6015be6db89eb03e2f1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -252,19 +360,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
 ]
 
 [[package]]
 name = "ark-vesta"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a6d658e5e7380af710828550b2dc2c7b033c9f3103d2690711cb07d5a62df6"
+checksum = "64149c07e3d07ee2263e831cf747ecf77c58d90a9cfa2813fc45c39dc5c92964"
 dependencies = [
- "ark-ec",
- "ark-ff",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
  "ark-pallas",
- "ark-std",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
@@ -370,9 +488,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitvec"
@@ -397,18 +515,18 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.11.0-rc.5"
+version = "0.11.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52965399b470437fc7f4d4b51134668dbc96573fea6f1b83318a420e4605745"
+checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
 dependencies = [
  "digest 0.11.2",
 ]
 
 [[package]]
 name = "blake3"
-version = "1.8.4"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -520,9 +638,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -556,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -578,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -680,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crossbeam-deque"
@@ -1139,6 +1257,9 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -1211,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
@@ -1319,12 +1440,12 @@ dependencies = [
 
 [[package]]
 name = "k12"
-version = "0.4.0-rc.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa927b6b9fe8e3f343efda8787220d161a6ba87159739c7affe33a733af8fd07"
+checksum = "aa4b15f0fd1abbca1aa77ec18076d1b893c02979c27d84d1b3b422f3153c1763"
 dependencies = [
  "digest 0.11.2",
- "sha3",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -1358,6 +1479,7 @@ checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1368,9 +1490,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libtest-mimic"
@@ -1426,7 +1548,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block",
  "core-graphics-types",
  "foreign-types",
@@ -1829,7 +1951,7 @@ dependencies = [
  "pallas-crypto",
  "pallas-primitives",
  "pallas-traverse",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1888,7 +2010,7 @@ dependencies = [
  "itertools 0.13.0",
  "pallas-codec",
  "pallas-crypto",
- "rand 0.8.5",
+ "rand 0.8.6",
  "socket2 0.5.10",
  "thiserror",
  "tokio",
@@ -1972,7 +2094,7 @@ dependencies = [
  "cryptoxide",
  "ed25519-bip32",
  "pallas-crypto",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror",
 ]
 
@@ -2207,9 +2329,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -2258,9 +2380,9 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -2397,7 +2519,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2633,16 +2755,16 @@ version = "0.6.0"
 dependencies = [
  "ark-bls12-381",
  "ark-curve25519",
- "ark-ec",
- "ark-ff",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
  "ark-pallas",
  "ark-secp256k1",
  "ark-secp256r1",
- "ark-serialize",
- "ark-std",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
  "ark-vesta",
  "ascon",
- "blake2 0.11.0-rc.5",
+ "blake2 0.11.0-rc.6",
  "blake3",
  "bls12_381",
  "curve25519-dalek",
@@ -2658,7 +2780,7 @@ dependencies = [
  "p3-koala-bear",
  "p3-mersenne-31",
  "pallas",
- "rand 0.8.5",
+ "rand 0.8.6",
  "risc0-zkp",
  "serde",
  "serde_json",
@@ -2825,9 +2947,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -2966,9 +3088,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -3027,11 +3149,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -3040,7 +3162,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -3116,7 +3238,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -3265,9 +3387,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -3280,6 +3402,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -3330,7 +3458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap 2.14.0",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,6 +1125,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
  "foldhash",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,3 +80,8 @@ spongefish = { version = "0.6.0", path = "spongefish" }
 spongefish-circuit = { version = "0.6.0", path = "circuit" }
 spongefish-derive = { version = "0.6.0", path = "derive" }
 zeroize = "^1.8.1"
+
+# SmallFp is not yet published in ark-ff 0.5.0, so we patch ark-ff and ark-serialize from git master.
+[patch.crates-io]
+ark-ff = { git = "https://github.com/arkworks-rs/algebra", package = "ark-ff" }
+ark-serialize = { git = "https://github.com/arkworks-rs/algebra", package = "ark-serialize" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,9 +88,17 @@ spongefish-circuit = { version = "0.6.1", path = "circuit" }
 spongefish-derive = { version = "0.6.1", path = "derive" }
 zeroize = "^1.8.1"
 
-# ark-curve25519, ark-secp256k1, ark-secp256r1 don't yet have 0.6 releases on crates.io.
-# Pull them — and the algebra crates they share — from the algebra release/0.6.0 branch
-# so the workspace resolves to a single set of ark-ff/ark-ec/ark-serialize crates.
+# ark-curve25519, ark-secp256k1, ark-secp256r1 don't yet have 0.6 releases on
+# crates.io, so we patch them from the algebra release/0.6.0 branch.
+#
+# ark-ec, ark-ff, ark-serialize 0.6.0 are on crates.io, but we have to patch
+# them too: the patched curves above declare those deps via `workspace = true`,
+# which the algebra workspace resolves to `path = "./{ff,ec,serialize}"` —
+# i.e. an in-repo source. Without these patches cargo ends up with two copies
+# of each (crates.io + git, both 0.6.0), and the `Fp`/`Projective` types
+# served by the curve crates don't match the trait impls in spongefish.
+#
+# Drop the bottom three lines once the curve crates ship 0.6 to crates.io.
 [patch.crates-io]
 ark-curve25519 = { git = "https://github.com/arkworks-rs/algebra", branch = "release/0.6.0" }
 ark-secp256k1 = { git = "https://github.com/arkworks-rs/algebra", branch = "release/0.6.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,12 +39,12 @@ naive_bytecount = "allow"
 [workspace.dependencies]
 ark-bls12-381 = "^0.6"
 ark-bn254 = "^0.6"
-ark-curve25519 = "^0.5"
+ark-curve25519 = "^0.6"
 ark-ec = "^0.6"
 ark-ff = "^0.6"
 ark-pallas = "^0.6"
-ark-secp256k1 = "^0.5"
-ark-secp256r1 = "^0.5"
+ark-secp256k1 = "^0.6"
+ark-secp256r1 = "^0.6"
 ark-serialize = "^0.6"
 ark-std = "^0.6"
 ark-vesta = "^0.6"
@@ -56,7 +56,7 @@ bytemuck = "^1.22"
 curve25519-dalek = "^4.1"
 digest = "0.11.2"
 hex = "0.4.3"
-k12 = "0.4.0-rc.1"
+k12 = "0.4.0"
 k256 = "^0.13"
 keccak = "^0.1.5"
 libtest-mimic = "0.8.1"
@@ -81,3 +81,14 @@ spongefish = { version = "0.6.1", path = "spongefish" }
 spongefish-circuit = { version = "0.6.1", path = "circuit" }
 spongefish-derive = { version = "0.6.1", path = "derive" }
 zeroize = "^1.8.1"
+
+# ark-curve25519, ark-secp256k1, ark-secp256r1 don't yet have 0.6 releases on crates.io.
+# Pull them — and the algebra crates they share — from the algebra release/0.6.0 branch
+# so the workspace resolves to a single set of ark-ff/ark-ec/ark-serialize crates.
+[patch.crates-io]
+ark-curve25519 = { git = "https://github.com/arkworks-rs/algebra", branch = "release/0.6.0" }
+ark-secp256k1 = { git = "https://github.com/arkworks-rs/algebra", branch = "release/0.6.0" }
+ark-secp256r1 = { git = "https://github.com/arkworks-rs/algebra", branch = "release/0.6.0" }
+ark-ec = { git = "https://github.com/arkworks-rs/algebra", branch = "release/0.6.0" }
+ark-ff = { git = "https://github.com/arkworks-rs/algebra", branch = "release/0.6.0" }
+ark-serialize = { git = "https://github.com/arkworks-rs/algebra", branch = "release/0.6.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ hashbrown = { version = "0.15.5", default-features = false, features = [
 ] }
 hex = "0.4.3"
 itertools = { version = "0.14.0", features = ["use_alloc"], default-features = false }
-k12 = "0.4.0-rc.1"
+k12 = "0.4.0"
 k256 = "^0.13"
 keccak = "^0.1.5"
 libtest-mimic = "0.8.1"
@@ -87,22 +87,3 @@ spongefish = { version = "0.6.1", path = "spongefish" }
 spongefish-circuit = { version = "0.6.1", path = "circuit" }
 spongefish-derive = { version = "0.6.1", path = "derive" }
 zeroize = "^1.8.1"
-
-# ark-curve25519, ark-secp256k1, ark-secp256r1 don't yet have 0.6 releases on
-# crates.io, so we patch them from the algebra release/0.6.0 branch.
-#
-# ark-ec, ark-ff, ark-serialize 0.6.0 are on crates.io, but we have to patch
-# them too: the patched curves above declare those deps via `workspace = true`,
-# which the algebra workspace resolves to `path = "./{ff,ec,serialize}"` —
-# i.e. an in-repo source. Without these patches cargo ends up with two copies
-# of each (crates.io + git, both 0.6.0), and the `Fp`/`Projective` types
-# served by the curve crates don't match the trait impls in spongefish.
-#
-# Drop the bottom three lines once the curve crates ship 0.6 to crates.io.
-[patch.crates-io]
-ark-curve25519 = { git = "https://github.com/arkworks-rs/algebra", branch = "release/0.6.0" }
-ark-secp256k1 = { git = "https://github.com/arkworks-rs/algebra", branch = "release/0.6.0" }
-ark-secp256r1 = { git = "https://github.com/arkworks-rs/algebra", branch = "release/0.6.0" }
-ark-ec = { git = "https://github.com/arkworks-rs/algebra", branch = "release/0.6.0" }
-ark-ff = { git = "https://github.com/arkworks-rs/algebra", branch = "release/0.6.0" }
-ark-serialize = { git = "https://github.com/arkworks-rs/algebra", branch = "release/0.6.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,17 +36,17 @@ tuple_array_conversions = "allow"
 naive_bytecount = "allow"
 
 [workspace.dependencies]
-ark-bls12-381 = "^0.5"
-ark-bn254 = "^0.5"
+ark-bls12-381 = "^0.6"
+ark-bn254 = "^0.6"
 ark-curve25519 = "^0.5"
-ark-ec = "^0.5"
-ark-ff = "^0.5"
-ark-pallas = "^0.5"
+ark-ec = "^0.6"
+ark-ff = "^0.6"
+ark-pallas = "^0.6"
 ark-secp256k1 = "^0.5"
 ark-secp256r1 = "^0.5"
-ark-serialize = "^0.5"
-ark-std = "^0.5"
-ark-vesta = "^0.5"
+ark-serialize = "^0.6"
+ark-std = "^0.6"
+ark-vesta = "^0.6"
 arrayvec = "0.7.6"
 blake2 = "0.11.0-rc.5"
 blake3 = { version = "^1.8.4", features = ["traits-preview", "zeroize"] }
@@ -80,8 +80,3 @@ spongefish = { version = "0.6.0", path = "spongefish" }
 spongefish-circuit = { version = "0.6.0", path = "circuit" }
 spongefish-derive = { version = "0.6.0", path = "derive" }
 zeroize = "^1.8.1"
-
-# SmallFp is not yet published in ark-ff 0.5.0, so we patch ark-ff and ark-serialize from git master.
-[patch.crates-io]
-ark-ff = { git = "https://github.com/arkworks-rs/algebra", package = "ark-ff" }
-ark-serialize = { git = "https://github.com/arkworks-rs/algebra", package = "ark-serialize" }

--- a/spongefish/src/drivers/ark_ff_impl.rs
+++ b/spongefish/src/drivers/ark_ff_impl.rs
@@ -98,7 +98,7 @@ macro_rules! impl_encoding {
                 let mut buf = Vec::with_capacity(base_field_size * <Self as Field>::extension_degree() as usize);
                 for base_element in self.to_base_prime_field_elements() {
                     let bytes = base_element.into_bigint().to_bytes_be();
-                    // Handle BigInt wider than the field (SmallFp: BigInt<2> for 8-byte field).
+                    // Handle BigInt wider than the field (e.g. F16 inside SmallFp's BigInt<1>).
                     let start = bytes.len().saturating_sub(base_field_size);
                     // Handle BigInt narrower than the field (defensive).
                     let padding = base_field_size.saturating_sub(bytes.len());
@@ -142,26 +142,7 @@ impl_deserialize!(impl [C: ark_ff::Fp3Config] for ark_ff::Fp3<C>);
 impl_deserialize!(impl [C: ark_ff::Fp4Config] for ark_ff::Fp4<C>);
 impl_deserialize!(impl [C: ark_ff::Fp6Config] for ark_ff::Fp6<C>);
 impl_deserialize!(impl [C: ark_ff::Fp12Config] for ark_ff::Fp12<C>);
-// SmallFp NargDeserialize: read exactly ⌈MODULUS_BIT_SIZE / 8⌉ BE bytes and
-// reconstruct via the field's canonical PrimeField::BigInt type. We can't use the
-// macro because `from_be_bytes_mod_order` reduces non-canonical encodings instead
-// of rejecting them.
-impl<P: SmallFpConfig> NargDeserialize for SmallFp<P> {
-    fn deserialize_from_narg(buf: &mut &[u8]) -> VerificationResult<Self> {
-        let base_field_size = (Self::MODULUS_BIT_SIZE.div_ceil(8)) as usize;
-        if buf.len() < base_field_size {
-            return Err(VerificationError);
-        }
-        let (head, tail) = buf.split_at(base_field_size);
-        *buf = tail;
-        let bits = head
-            .iter()
-            .flat_map(|byte| (0..8).rev().map(move |shift| (byte >> shift) & 1 == 1))
-            .collect::<Vec<_>>();
-        let bigint = <Self as PrimeField>::BigInt::from_bits_be(&bits);
-        Self::from_bigint(bigint).ok_or(VerificationError)
-    }
-}
+impl_deserialize!(impl [P: SmallFpConfig] for SmallFp<P>);
 // Implement Encoding for prime-order field and field extensions.
 // The NargSerialize implementation is inherited here.
 impl_encoding!(impl [C: FpConfig<N>, const N: usize] for Fp<C, N>);
@@ -170,6 +151,7 @@ impl_encoding!(impl [C: ark_ff::Fp3Config] for ark_ff::Fp3<C>);
 impl_encoding!(impl [C: ark_ff::Fp4Config] for ark_ff::Fp4<C>);
 impl_encoding!(impl [C: ark_ff::Fp6Config] for ark_ff::Fp6<C>);
 impl_encoding!(impl [C: ark_ff::Fp12Config] for ark_ff::Fp12<C>);
+impl_encoding!(impl [P: SmallFpConfig] for SmallFp<P>);
 // Implement Decoding for prime-order fields and field extensions.
 impl_decoding!(impl [C: FpConfig<N>, const N: usize] for Fp<C, N>);
 impl_decoding!(impl [C: ark_ff::Fp2Config] for ark_ff::Fp2<C>);
@@ -177,29 +159,7 @@ impl_decoding!(impl [C: ark_ff::Fp3Config] for ark_ff::Fp3<C>);
 impl_decoding!(impl [C: ark_ff::Fp4Config] for ark_ff::Fp4<C>);
 impl_decoding!(impl [C: ark_ff::Fp6Config] for ark_ff::Fp6<C>);
 impl_decoding!(impl [C: ark_ff::Fp12Config] for ark_ff::Fp12<C>);
-
-// SmallFp Encoding: serialize exactly ⌈MODULUS_BIT_SIZE / 8⌉ bytes per element,
-// computed from the modulus rather than the BigInt backing width.
-impl<P: SmallFpConfig> Encoding<[u8]> for SmallFp<P> {
-    fn encode(&self) -> impl AsRef<[u8]> {
-        let base_field_size = (Self::MODULUS_BIT_SIZE.div_ceil(8)) as usize;
-        let mut bytes = self.into_bigint().to_bytes_be();
-        // BigInt<2> produces 16 BE bytes; drop the leading zeros to keep
-        // only the ⌈MODULUS_BIT_SIZE / 8⌉ significant bytes.
-        bytes.drain(..bytes.len() - base_field_size);
-        bytes
-    }
-}
-
-// SmallFp Decoding: uniform random sampling from squeezed bytes.
-impl<P: SmallFpConfig> Decoding<[u8]> for SmallFp<P> {
-    type Repr = DecodingFieldBuffer<Self>;
-
-    fn decode(repr: Self::Repr) -> Self {
-        debug_assert_eq!(repr.buf.len(), decoding_field_buffer_size::<Self>());
-        Self::from_le_bytes_mod_order(&repr.buf)
-    }
-}
+impl_decoding!(impl [P: SmallFpConfig] for SmallFp<P>);
 
 /// Number of uniformly random bits in a uniformly-distributed element in `[0, b)`
 ///
@@ -338,8 +298,8 @@ mod test_ark_ff {
     /// is not canonical because p ≡ 0 and 0 already has its own encoding.
     fn reject_modulus<F: ark_ff::PrimeField + core::fmt::Debug + crate::io::NargDeserialize>() {
         let modulus_bytes = F::MODULUS.to_bytes_be();
-        // Keep only the trailing ⌈MODULUS_BIT_SIZE/8⌉ bytes (SmallFp BigInt<2>
-        // produces 16 BE bytes but the serialisation is shorter).
+        // Keep only the trailing ⌈MODULUS_BIT_SIZE/8⌉ bytes; the backing BigInt
+        // can be wider than the field (e.g. F16 inside SmallFp's BigInt<1>).
         let field_size = F::MODULUS_BIT_SIZE.div_ceil(8) as usize;
         let start = modulus_bytes.len().saturating_sub(field_size);
         let trimmed = &modulus_bytes[start..];

--- a/spongefish/src/drivers/ark_ff_impl.rs
+++ b/spongefish/src/drivers/ark_ff_impl.rs
@@ -12,6 +12,11 @@ use crate::{
 };
 
 fn parse_canonical_prime_field<F: PrimeField>(bytes: &[u8]) -> Option<F> {
+    // A canonical encoding of an element of [0, p) fits in ⌈MODULUS_BIT_SIZE/8⌉ bytes.
+    // Reject any longer input up front, before allocating.
+    if bytes.len() > (F::MODULUS_BIT_SIZE as usize).div_ceil(8) {
+        return None;
+    }
     let bits = bytes
         .iter()
         .flat_map(|byte| (0..8).rev().map(move |shift| (byte >> shift) & 1 == 1))

--- a/spongefish/src/drivers/ark_ff_impl.rs
+++ b/spongefish/src/drivers/ark_ff_impl.rs
@@ -2,7 +2,7 @@
 use alloc::{vec, vec::Vec};
 use core::marker::PhantomData;
 
-use ark_ff::{BigInteger, Field, Fp, FpConfig, PrimeField};
+use ark_ff::{BigInteger, Field, Fp, FpConfig, PrimeField, SmallFp, SmallFpConfig};
 
 use crate::{
     codecs::{Decoding, Encoding},
@@ -23,6 +23,11 @@ fn parse_canonical_prime_field<F: PrimeField>(bytes: &[u8]) -> Option<F> {
 // Make arkworks field elements a valid Unit type
 impl<C: ark_ff::FpConfig<N>, const N: usize> crate::Unit for Fp<C, N> {
     const ZERO: Self = C::ZERO;
+}
+
+// Make SmallFp field elements a valid Unit type
+impl<P: SmallFpConfig> crate::Unit for SmallFp<P> {
+    const ZERO: Self = P::ZERO;
 }
 
 /// A buffer meant to hold enough bytes for obtaining a uniformly-distributed
@@ -93,9 +98,12 @@ macro_rules! impl_encoding {
                 let mut buf = Vec::with_capacity(base_field_size * <Self as Field>::extension_degree() as usize);
                 for base_element in self.to_base_prime_field_elements() {
                     let bytes = base_element.into_bigint().to_bytes_be();
+                    // Handle BigInt wider than the field (SmallFp: BigInt<2> for 8-byte field).
+                    let start = bytes.len().saturating_sub(base_field_size);
+                    // Handle BigInt narrower than the field (defensive).
                     let padding = base_field_size.saturating_sub(bytes.len());
                     buf.extend(core::iter::repeat_n(0, padding));
-                    buf.extend_from_slice(&bytes);
+                    buf.extend_from_slice(&bytes[start..]);
                 }
                 buf
             }
@@ -111,7 +119,7 @@ macro_rules! impl_encoding {
 macro_rules! impl_decoding {
         (impl [$($generics:tt)*] for $type:ty) => {
         impl<$($generics)*> Decoding<[u8]> for $type {
-            type Repr = DecodingFieldBuffer<$type>;
+            type Repr = DecodingFieldBuffer<Self>;
 
             fn decode(repr: Self::Repr) -> Self {
                 debug_assert_eq!(repr.buf.len(), decoding_field_buffer_size::<Self>());
@@ -134,6 +142,26 @@ impl_deserialize!(impl [C: ark_ff::Fp3Config] for ark_ff::Fp3<C>);
 impl_deserialize!(impl [C: ark_ff::Fp4Config] for ark_ff::Fp4<C>);
 impl_deserialize!(impl [C: ark_ff::Fp6Config] for ark_ff::Fp6<C>);
 impl_deserialize!(impl [C: ark_ff::Fp12Config] for ark_ff::Fp12<C>);
+// SmallFp NargDeserialize: read exactly ⌈MODULUS_BIT_SIZE / 8⌉ BE bytes and
+// reconstruct via the field's canonical PrimeField::BigInt type. We can't use the
+// macro because `from_be_bytes_mod_order` reduces non-canonical encodings instead
+// of rejecting them.
+impl<P: SmallFpConfig> NargDeserialize for SmallFp<P> {
+    fn deserialize_from_narg(buf: &mut &[u8]) -> VerificationResult<Self> {
+        let base_field_size = (Self::MODULUS_BIT_SIZE.div_ceil(8)) as usize;
+        if buf.len() < base_field_size {
+            return Err(VerificationError);
+        }
+        let (head, tail) = buf.split_at(base_field_size);
+        *buf = tail;
+        let bits = head
+            .iter()
+            .flat_map(|byte| (0..8).rev().map(move |shift| (byte >> shift) & 1 == 1))
+            .collect::<Vec<_>>();
+        let bigint = <Self as PrimeField>::BigInt::from_bits_be(&bits);
+        Self::from_bigint(bigint).ok_or(VerificationError)
+    }
+}
 // Implement Encoding for prime-order field and field extensions.
 // The NargSerialize implementation is inherited here.
 impl_encoding!(impl [C: FpConfig<N>, const N: usize] for Fp<C, N>);
@@ -149,6 +177,29 @@ impl_decoding!(impl [C: ark_ff::Fp3Config] for ark_ff::Fp3<C>);
 impl_decoding!(impl [C: ark_ff::Fp4Config] for ark_ff::Fp4<C>);
 impl_decoding!(impl [C: ark_ff::Fp6Config] for ark_ff::Fp6<C>);
 impl_decoding!(impl [C: ark_ff::Fp12Config] for ark_ff::Fp12<C>);
+
+// SmallFp Encoding: serialize exactly ⌈MODULUS_BIT_SIZE / 8⌉ bytes per element,
+// computed from the modulus rather than the BigInt backing width.
+impl<P: SmallFpConfig> Encoding<[u8]> for SmallFp<P> {
+    fn encode(&self) -> impl AsRef<[u8]> {
+        let base_field_size = (Self::MODULUS_BIT_SIZE.div_ceil(8)) as usize;
+        let mut bytes = self.into_bigint().to_bytes_be();
+        // BigInt<2> produces 16 BE bytes; drop the leading zeros to keep
+        // only the ⌈MODULUS_BIT_SIZE / 8⌉ significant bytes.
+        bytes.drain(..bytes.len() - base_field_size);
+        bytes
+    }
+}
+
+// SmallFp Decoding: uniform random sampling from squeezed bytes.
+impl<P: SmallFpConfig> Decoding<[u8]> for SmallFp<P> {
+    type Repr = DecodingFieldBuffer<Self>;
+
+    fn decode(repr: Self::Repr) -> Self {
+        debug_assert_eq!(repr.buf.len(), decoding_field_buffer_size::<Self>());
+        Self::from_le_bytes_mod_order(&repr.buf)
+    }
+}
 
 /// Number of uniformly random bits in a uniformly-distributed element in `[0, b)`
 ///
@@ -197,33 +248,245 @@ impl<F: Field> AsMut<[u8]> for DecodingFieldBuffer<F> {
 mod test_ark_ff {
     use ark_ff::{BigInteger, PrimeField};
 
-    use crate::{codecs::Encoding, io::NargDeserialize};
+    use crate::{
+        codecs::Encoding,
+        io::{NargDeserialize, NargSerialize},
+    };
 
-    fn encoding_testsuite<F: ark_ff::Field + Encoding<[u8]>>() {
-        let first = F::from(10);
-        let second = F::from(20);
-        let first_encoding = Encoding::<[u8]>::encode(&first);
-        let second_encoding = Encoding::<[u8]>::encode(&second);
-        assert_ne!(first_encoding.as_ref(), second_encoding.as_ref());
+    // ----- SmallFp test fields -----
 
-        let first = F::from(10);
-        let second = -F::from(10) + F::from(20);
-        assert_eq!(
-            Encoding::encode(&first).as_ref(),
-            Encoding::encode(&second).as_ref()
-        );
-        assert_eq!(
-            Encoding::encode(&[first, second]).as_ref(),
-            Encoding::encode(&[second, first]).as_ref()
+    // Goldilocks field: p = 2^64 - 2^32 + 1
+    ark_ff::define_field!(
+        modulus = "18446744069414584321",
+        generator = "7",
+        name = Goldilocks,
+    );
+
+    // Mersenne31 field: p = 2^31 - 1
+    ark_ff::define_field!(modulus = "2147483647", generator = "7", name = M31,);
+
+    // BabyBear field: p = 15 * 2^27 + 1
+    ark_ff::define_field!(modulus = "2013265921", generator = "31", name = BabyBear,);
+
+    // KoalaBear field: p = 2^31 - 2^24 + 1
+    ark_ff::define_field!(modulus = "2130706433", generator = "3", name = KoalaBear,);
+
+    // A 16-bit test field: p = 65521 (largest 16-bit prime)
+    ark_ff::define_field!(modulus = "65521", generator = "17", name = F16,);
+
+    // ----- Encoding / serialization round-trip tests -----
+
+    /// Encode → serialize → deserialize round-trip, testing zero, one, p-1,
+    /// and a handful of interior values.
+    fn roundtrip_testsuite<F>()
+    where
+        F: ark_ff::PrimeField
+            + Encoding<[u8]>
+            + crate::io::NargSerialize
+            + crate::io::NargDeserialize,
+    {
+        for v in [0u64, 1, 42, 12345] {
+            let original = F::from(v);
+            let serialized = encode_to_vec(&original);
+            let mut slice: &[u8] = &serialized;
+            let deserialized = F::deserialize_from_narg(&mut slice)
+                .unwrap_or_else(|_| panic!("failed to deserialize value {v}"));
+            assert!(
+                slice.is_empty(),
+                "deserialize did not consume all bytes for value {v}"
+            );
+            assert_eq!(original, deserialized, "roundtrip mismatch for {v}");
+        }
+
+        // p - 1 (the largest valid element)
+        let p_minus_1 = -F::ONE;
+        let ser = encode_to_vec(&p_minus_1);
+        let mut sl: &[u8] = &ser;
+        let de = F::deserialize_from_narg(&mut sl).expect("p-1 should deserialize");
+        assert!(sl.is_empty());
+        assert_eq!(de, p_minus_1);
+    }
+
+    fn encode_to_vec<F: Encoding<[u8]>>(x: &F) -> alloc::vec::Vec<u8> {
+        let mut dst = alloc::vec::Vec::new();
+        x.serialize_into_narg(&mut dst);
+        dst
+    }
+
+    /// Encoding the same value twice must produce identical bytes.
+    fn deterministic_encoding_testsuite<F: ark_ff::Field + Encoding<[u8]>>() {
+        for v in [0u64, 1, 42, 12345] {
+            let elem = F::from(v);
+            let a = encode_to_vec(&elem);
+            let b = encode_to_vec(&elem);
+            assert_eq!(a, b, "encoding not deterministic for {v}");
+        }
+    }
+
+    /// Distinct values must encode differently.
+    fn distinct_values_encode_differently<F: ark_ff::PrimeField + Encoding<[u8]>>() {
+        let zero = encode_to_vec(&F::ZERO);
+        let one = encode_to_vec(&F::ONE);
+        let p_minus_1 = encode_to_vec(&(-F::ONE));
+
+        assert_ne!(zero, one);
+        assert_ne!(one, p_minus_1);
+        assert_ne!(zero, p_minus_1);
+    }
+
+    /// Deserializing p (the modulus itself) must fail — the encoding
+    /// is not canonical because p ≡ 0 and 0 already has its own encoding.
+    fn reject_modulus<F: ark_ff::PrimeField + core::fmt::Debug + crate::io::NargDeserialize>() {
+        let modulus_bytes = F::MODULUS.to_bytes_be();
+        // Keep only the trailing ⌈MODULUS_BIT_SIZE/8⌉ bytes (SmallFp BigInt<2>
+        // produces 16 BE bytes but the serialisation is shorter).
+        let field_size = F::MODULUS_BIT_SIZE.div_ceil(8) as usize;
+        let start = modulus_bytes.len().saturating_sub(field_size);
+        let trimmed = &modulus_bytes[start..];
+        let mut sl: &[u8] = trimmed;
+        assert!(
+            F::deserialize_from_narg(&mut sl).is_err(),
+            "deserializing p should fail (modulus_bits={}, field_size={field_size}, trimmed={trimmed:?})",
+            F::MODULUS_BIT_SIZE,
         );
     }
 
+    /// A single bit-flip must either change the decoded value or cause rejection.
+    fn bitflip_testsuite<F>()
+    where
+        F: ark_ff::PrimeField + Encoding<[u8]> + crate::io::NargDeserialize,
+    {
+        let original = F::from(42u64);
+        let encoded = encode_to_vec(&original);
+
+        for byte_idx in 0..encoded.len() {
+            for bit in 0..8u8 {
+                let mut flipped = encoded.clone();
+                flipped[byte_idx] ^= 1 << bit;
+                let mut sl: &[u8] = &flipped;
+                if let Ok(v) = F::deserialize_from_narg(&mut sl) {
+                    assert_ne!(
+                        v, original,
+                        "bit-flip at byte {byte_idx} bit {bit} decoded to same value"
+                    );
+                } // rejection is fine
+            }
+        }
+    }
+
+    /// Truncated buffer must be rejected.
+    fn wrong_length_testsuite<F>()
+    where
+        F: ark_ff::PrimeField + Encoding<[u8]> + crate::io::NargDeserialize,
+    {
+        let encoded = encode_to_vec(&F::from(1u64));
+
+        // Truncated: one byte short
+        if !encoded.is_empty() {
+            let short = &encoded[..encoded.len() - 1];
+            let mut sl: &[u8] = short;
+            assert!(
+                F::deserialize_from_narg(&mut sl).is_err(),
+                "truncated buffer should fail"
+            );
+        }
+    }
+
     #[test]
-    fn test_encoding() {
-        encoding_testsuite::<ark_bls12_381::Fr>();
-        encoding_testsuite::<ark_bls12_381::Fq>();
-        encoding_testsuite::<ark_bls12_381::Fq2>();
-        encoding_testsuite::<ark_bls12_381::Fq12>();
+    fn test_smallfp_roundtrip() {
+        roundtrip_testsuite::<Goldilocks>();
+        roundtrip_testsuite::<M31>();
+        roundtrip_testsuite::<BabyBear>();
+        roundtrip_testsuite::<KoalaBear>();
+        roundtrip_testsuite::<F16>();
+    }
+
+    #[test]
+    fn test_smallfp_deterministic_encoding() {
+        deterministic_encoding_testsuite::<Goldilocks>();
+        deterministic_encoding_testsuite::<M31>();
+        deterministic_encoding_testsuite::<BabyBear>();
+        deterministic_encoding_testsuite::<KoalaBear>();
+        deterministic_encoding_testsuite::<F16>();
+    }
+
+    #[test]
+    fn test_smallfp_distinct_values_encode_differently() {
+        distinct_values_encode_differently::<Goldilocks>();
+        distinct_values_encode_differently::<M31>();
+        distinct_values_encode_differently::<BabyBear>();
+        distinct_values_encode_differently::<KoalaBear>();
+        distinct_values_encode_differently::<F16>();
+    }
+
+    #[test]
+    fn test_smallfp_reject_modulus() {
+        reject_modulus::<Goldilocks>();
+        reject_modulus::<M31>();
+        reject_modulus::<BabyBear>();
+        reject_modulus::<KoalaBear>();
+        // F16 modulus is 65521, which fits in 2 bytes. Encoding is 2 BE bytes.
+        reject_modulus::<F16>();
+    }
+
+    #[test]
+    fn test_smallfp_bitflip() {
+        bitflip_testsuite::<Goldilocks>();
+        bitflip_testsuite::<M31>();
+        bitflip_testsuite::<BabyBear>();
+        bitflip_testsuite::<KoalaBear>();
+        bitflip_testsuite::<F16>();
+    }
+
+    #[test]
+    fn test_smallfp_wrong_length() {
+        wrong_length_testsuite::<Goldilocks>();
+        wrong_length_testsuite::<M31>();
+        wrong_length_testsuite::<BabyBear>();
+        wrong_length_testsuite::<KoalaBear>();
+        wrong_length_testsuite::<F16>();
+    }
+
+    // ----- MontFp (large field) tests -----
+
+    #[test]
+    fn test_montfp_roundtrip() {
+        roundtrip_testsuite::<ark_bls12_381::Fr>();
+        roundtrip_testsuite::<ark_bls12_381::Fq>();
+    }
+
+    #[test]
+    fn test_montfp_reject_modulus() {
+        reject_modulus::<ark_bls12_381::Fr>();
+        reject_modulus::<ark_bls12_381::Fq>();
+    }
+
+    #[test]
+    fn test_montfp_bitflip() {
+        bitflip_testsuite::<ark_bls12_381::Fr>();
+    }
+
+    // ----- SmallFp extension field (Fp2) -----
+
+    pub struct GoldilocksFp2Config;
+    impl ark_ff::Fp2Config for GoldilocksFp2Config {
+        type Fp = Goldilocks;
+
+        // 7 is a quadratic non-residue mod Goldilocks
+        const NONRESIDUE: Self::Fp = ark_ff::SmallFp::from_raw(7);
+
+        const FROBENIUS_COEFF_FP2_C1: &'static [Self::Fp] = &[
+            // 7^(((q^0) - 1) / 2) = 1
+            ark_ff::SmallFp::from_raw(1),
+            // 7^(((q^1) - 1) / 2) = p - 1
+            ark_ff::SmallFp::from_raw(18_446_744_069_414_584_320),
+        ];
+    }
+    pub type GoldilocksFp2 = ark_ff::Fp2<GoldilocksFp2Config>;
+
+    #[test]
+    fn test_encoding_small_fp_goldilocks_fp2() {
+        deterministic_encoding_testsuite::<GoldilocksFp2>();
     }
 
     #[test]

--- a/spongefish/src/drivers/tests.rs
+++ b/spongefish/src/drivers/tests.rs
@@ -227,6 +227,30 @@ fn secp256r1_scalars_arkworks_and_p256() {
     assert_decoding_compatibility::<ArkP256Scalar, P256Scalar>();
 }
 
+#[cfg(all(feature = "ark-ff", feature = "p3-baby-bear"))]
+#[test]
+fn babybear_scalars_arkworks_and_p3() {
+    ark_ff::define_field!(modulus = "2013265921", generator = "31", name = ArkBabyBear,);
+
+    for value in [0u64, 1, 42, 123_456_789] {
+        let ark_scalar = ArkBabyBear::from(value);
+        let p3_scalar = p3_baby_bear::BabyBear::new(value as u32);
+        assert_codec_compatibility(&ark_scalar, &p3_scalar);
+    }
+}
+
+#[cfg(all(feature = "ark-ff", feature = "p3-koala-bear"))]
+#[test]
+fn koalabear_scalars_arkworks_and_p3() {
+    ark_ff::define_field!(modulus = "2130706433", generator = "3", name = ArkKoalaBear,);
+
+    for value in [0u64, 1, 42, 123_456_789] {
+        let ark_scalar = ArkKoalaBear::from(value);
+        let p3_scalar = p3_koala_bear::KoalaBear::new(value as u32);
+        assert_codec_compatibility(&ark_scalar, &p3_scalar);
+    }
+}
+
 #[cfg(feature = "ark-ff")]
 #[test]
 fn narg_ark_ff_advances_buffer() {

--- a/spongefish/src/instantiations/mod.rs
+++ b/spongefish/src/instantiations/mod.rs
@@ -26,11 +26,8 @@ pub type Ascon12 = DuplexSponge<permutations::Ascon12, 40, 16>;
 pub type Shake128 = xof::XOF<sha3::Shake128>;
 
 /// KangarooTwelve (K12) - fast reduced-round Keccak variant.
-///
-/// This alias fixes the customization-string lifetime to `'static` because the
-/// wrapper only exposes the default empty-customization constructor.
 #[cfg(feature = "k12")]
-pub type KangarooTwelve = xof::XOF<k12::Kt128<'static>>;
+pub type KangarooTwelve = xof::XOF<k12::Kt128>;
 
 /// Blake3's XOF used as a [`DuplexSpongeInterface`][`crate::DuplexSpongeInterface`].
 ///

--- a/spongefish/src/instantiations/xof.rs
+++ b/spongefish/src/instantiations/xof.rs
@@ -170,7 +170,7 @@ mod tests {
     #[cfg(feature = "k12")]
     #[test]
     fn kangaroo_twelve_clone_preserves_squeeze_position() {
-        assert_clone_preserves_squeeze_position::<k12::Kt128<'static>>();
+        assert_clone_preserves_squeeze_position::<k12::Kt128>();
     }
 
     #[cfg(feature = "blake3")]


### PR DESCRIPTION
What does this PR do?

- adds support for merged [Small Fp](https://github.com/arkworks-rs/algebra/pull/1044)
- doesn't change anything about Fp
- fix impl_encoding! that affects extension fields (Fp2, Fp3)
```text
to_bytes_be() → [00, 00, 00, 00, 00, 00, 00, 00, 01, 00, 00, 00, FF, FF, FF, FF]
resize(8, 0)  → [00, 00, 00, 00, 00, 00, 00, 00]                  // ❌ all zeros
drain(..8)    → [01, 00, 00, 00, FF, FF, FF, FF]                   // ✅ actual value
```