### PR TITLE
Hotfix release-plz config after poseidon2 removal

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -21,9 +21,5 @@ name = "spongefish-derive"
 version_group = "workspace"
 
 [[package]]
-name = "spongefish-poseidon2"
-version_group = "workspace"
-
-[[package]]
 name = "spongefish-pow"
 version_group = "workspace"


### PR DESCRIPTION
Summary:
- remove the stale spongefish-poseidon2 override from release-plz.toml
- align the release-plz workspace package list with the current workspace after the poseidon2 crate removal

Why:
The release job fails because release-plz still references spongefish-poseidon2, which is no longer in the workspace.

This hotfix removes that deleted crate from the release-plz config so the release workflow can determine next versions again.