### PR TITLE
feat: add RFC SHAKE128 transcript helpers

### DIFF
--- a/spongefish/src/domain_separator.rs
+++ b/spongefish/src/domain_separator.rs
@@ -96,6 +96,34 @@ where
     }
 }
 
+impl<I> DomainSeparator<WithInstance<'_, I>, [u8; 64]>
+where
+    I: Encoding<[u8]>,
+{
+    #[cfg(feature = "sha3")]
+    #[must_use]
+    pub fn std_prover_spec(&self) -> ProverState {
+        let default_session = session_id_spec(b"");
+        let session = self.session.as_ref().unwrap_or(&default_session);
+        let mut prover_state = ProverState::from(StdHash::from_iv(self.protocol));
+        prover_state.public_message(session);
+        prover_state.public_message(self.instance.0);
+        prover_state
+    }
+
+    #[cfg(feature = "sha3")]
+    #[must_use]
+    pub fn std_verifier_spec<'ver>(&self, narg_string: &'ver [u8]) -> VerifierState<'ver, StdHash> {
+        let default_session = session_id_spec(b"");
+        let session = self.session.as_ref().unwrap_or(&default_session);
+        let mut verifier_state =
+            VerifierState::from_parts(StdHash::from_iv(self.protocol), narg_string);
+        verifier_state.public_message(session);
+        verifier_state.public_message(self.instance.0);
+        verifier_state
+    }
+}
+
 impl<I, S> DomainSeparator<WithInstance<'_, I>, S> {
     pub fn to_prover<H>(&self, h: H) -> ProverState<H, StdRng>
     where
@@ -147,6 +175,20 @@ pub fn protocol_id(args: Arguments) -> [u8; 64] {
 
 #[inline]
 #[must_use]
+pub fn protocol_id_literal(protocol: &str) -> [u8; 64] {
+    let bytes = protocol.as_bytes();
+    assert!(
+        bytes.len() <= 64,
+        "protocol identifier must fit in 64 bytes"
+    );
+
+    let mut protocol_id = [0u8; 64];
+    protocol_id[..bytes.len()].copy_from_slice(bytes);
+    protocol_id
+}
+
+#[inline]
+#[must_use]
 pub fn session_id(args: Arguments) -> [u8; 64] {
     let mut sponge = StdHash::default();
 
@@ -158,6 +200,17 @@ pub fn session_id(args: Arguments) -> [u8; 64] {
     }
 
     sponge.squeeze_array()
+}
+
+#[inline]
+#[must_use]
+pub fn session_id_spec(session: &[u8]) -> [u8; 64] {
+    let mut sponge = StdHash::from_iv(protocol_id_literal("fiat-shamir/session-id"));
+    sponge.absorb(session);
+
+    let mut session_id = [0u8; 64];
+    sponge.squeeze(&mut session_id[32..]);
+    session_id
 }
 
 #[inline]

--- a/spongefish/src/domain_separator.rs
+++ b/spongefish/src/domain_separator.rs
@@ -86,39 +86,24 @@ where
     S: Encoding,
 {
     #[cfg(feature = "sha3")]
-    pub fn std_prover(&self) -> ProverState {
-        self.to_prover(StdHash::default())
-    }
-
-    #[cfg(feature = "sha3")]
-    pub fn std_verifier<'ver>(&self, narg_string: &'ver [u8]) -> VerifierState<'ver, StdHash> {
-        self.to_verifier(StdHash::default(), narg_string)
-    }
-}
-
-impl<I> DomainSeparator<WithInstance<'_, I>, [u8; 64]>
-where
-    I: Encoding<[u8]>,
-{
-    #[cfg(feature = "sha3")]
     #[must_use]
-    pub fn std_prover_spec(&self) -> ProverState {
-        let default_session = session_id_spec(b"");
-        let session = self.session.as_ref().unwrap_or(&default_session);
-        let mut prover_state = ProverState::from(StdHash::from_iv(self.protocol));
-        prover_state.public_message(session);
+    pub fn std_prover(&self) -> ProverState {
+        let mut prover_state = ProverState::from(StdHash::from_protocol_id(self.protocol));
+        if let Some(session_info) = &self.session {
+            prover_state.public_message(session_info);
+        }
         prover_state.public_message(self.instance.0);
         prover_state
     }
 
     #[cfg(feature = "sha3")]
     #[must_use]
-    pub fn std_verifier_spec<'ver>(&self, narg_string: &'ver [u8]) -> VerifierState<'ver, StdHash> {
-        let default_session = session_id_spec(b"");
-        let session = self.session.as_ref().unwrap_or(&default_session);
+    pub fn std_verifier<'ver>(&self, narg_string: &'ver [u8]) -> VerifierState<'ver, StdHash> {
         let mut verifier_state =
-            VerifierState::from_parts(StdHash::from_iv(self.protocol), narg_string);
-        verifier_state.public_message(session);
+            VerifierState::from_parts(StdHash::from_protocol_id(self.protocol), narg_string);
+        if let Some(session_info) = &self.session {
+            verifier_state.public_message(session_info);
+        }
         verifier_state.public_message(self.instance.0);
         verifier_state
     }
@@ -161,56 +146,23 @@ impl<I, S> DomainSeparator<WithInstance<'_, I>, S> {
 #[inline]
 #[must_use]
 pub fn protocol_id(args: Arguments) -> [u8; 64] {
-    let mut sponge = StdHash::default();
-
     if let Some(message) = args.as_str() {
-        sponge.absorb(message.as_bytes());
-    } else {
-        let formatted = alloc::fmt::format(args);
-        sponge.absorb(formatted.as_bytes());
+        return pad_identifier(message.as_bytes());
     }
 
-    sponge.squeeze_array()
-}
-
-#[inline]
-#[must_use]
-pub fn protocol_id_literal(protocol: &str) -> [u8; 64] {
-    let bytes = protocol.as_bytes();
-    assert!(
-        bytes.len() <= 64,
-        "protocol identifier must fit in 64 bytes"
-    );
-
-    let mut protocol_id = [0u8; 64];
-    protocol_id[..bytes.len()].copy_from_slice(bytes);
-    protocol_id
+    let formatted = alloc::fmt::format(args);
+    pad_identifier(formatted.as_bytes())
 }
 
 #[inline]
 #[must_use]
 pub fn session_id(args: Arguments) -> [u8; 64] {
-    let mut sponge = StdHash::default();
-
     if let Some(message) = args.as_str() {
-        sponge.absorb(message.as_bytes());
-    } else {
-        let formatted = alloc::fmt::format(args);
-        sponge.absorb(formatted.as_bytes());
+        return derive_session_id(message.as_bytes());
     }
 
-    sponge.squeeze_array()
-}
-
-#[inline]
-#[must_use]
-pub fn session_id_spec(session: &[u8]) -> [u8; 64] {
-    let mut sponge = StdHash::from_iv(protocol_id_literal("fiat-shamir/session-id"));
-    sponge.absorb(session);
-
-    let mut session_id = [0u8; 64];
-    sponge.squeeze(&mut session_id[32..]);
-    session_id
+    let formatted = alloc::fmt::format(args);
+    derive_session_id(formatted.as_bytes())
 }
 
 #[inline]
@@ -220,7 +172,25 @@ pub fn session_id_from_str<S>(value: &S) -> [u8; 64]
 where
     S: AsRef<str> + ?Sized,
 {
-    let mut sponge = StdHash::default();
-    sponge.absorb(value.as_ref().as_bytes());
-    sponge.squeeze_array()
+    derive_session_id(value.as_ref().as_bytes())
+}
+
+fn pad_identifier(identifier: &[u8]) -> [u8; 64] {
+    assert!(
+        identifier.len() <= 64,
+        "protocol identifier must fit in 64 bytes"
+    );
+
+    let mut protocol_id = [0u8; 64];
+    protocol_id[..identifier.len()].copy_from_slice(identifier);
+    protocol_id
+}
+
+fn derive_session_id(session: &[u8]) -> [u8; 64] {
+    let mut sponge = StdHash::from_protocol_id(pad_identifier(b"fiat-shamir/session-id"));
+    sponge.absorb(session);
+
+    let mut session_id = [0u8; 64];
+    sponge.squeeze(&mut session_id[32..]);
+    session_id
 }

--- a/spongefish/src/instantiations/xof.rs
+++ b/spongefish/src/instantiations/xof.rs
@@ -73,16 +73,14 @@ impl<H: ExtendableOutput + Default> Default for XOF<H> {
 
 #[cfg(feature = "sha3")]
 impl XOF<sha3::Shake128> {
-    /// Build a SHAKE128 sponge using the RFC test-vector IV convention.
-    #[must_use]
-    pub fn from_iv(iv: [u8; 64]) -> Self {
+    pub(crate) fn from_protocol_id(protocol_id: [u8; 64]) -> Self {
         use digest::Update;
 
         const RATE: usize = 168;
 
         let mut hasher = sha3::Shake128::default();
         let mut initial_block = [0u8; RATE];
-        initial_block[..iv.len()].copy_from_slice(&iv);
+        initial_block[..protocol_id.len()].copy_from_slice(&protocol_id);
         hasher.update(&initial_block);
 
         Self {

--- a/spongefish/src/instantiations/xof.rs
+++ b/spongefish/src/instantiations/xof.rs
@@ -70,3 +70,24 @@ impl<H: ExtendableOutput + Default> Default for XOF<H> {
         }
     }
 }
+
+#[cfg(feature = "sha3")]
+impl XOF<sha3::Shake128> {
+    /// Build a SHAKE128 sponge using the RFC test-vector IV convention.
+    #[must_use]
+    pub fn from_iv(iv: [u8; 64]) -> Self {
+        use digest::Update;
+
+        const RATE: usize = 168;
+
+        let mut hasher = sha3::Shake128::default();
+        let mut initial_block = [0u8; RATE];
+        initial_block[..iv.len()].copy_from_slice(&iv);
+        hasher.update(&initial_block);
+
+        Self {
+            hasher,
+            xof_reader: None,
+        }
+    }
+}

--- a/spongefish/src/lib.rs
+++ b/spongefish/src/lib.rs
@@ -215,7 +215,9 @@ pub use codecs::ByteArray;
 pub use codecs::{Codec, Decoding, Encoding};
 pub use domain_separator::DomainSeparator;
 #[doc(hidden)]
-pub use domain_separator::{protocol_id, session_id, session_id_from_str};
+pub use domain_separator::{
+    protocol_id, protocol_id_literal, session_id, session_id_from_str, session_id_spec,
+};
 pub use duplex_sponge::{DuplexSponge, DuplexSpongeInterface, Permutation, Unit};
 pub use error::{VerificationError, VerificationResult};
 pub use io::{NargDeserialize, NargSerialize};

--- a/spongefish/src/lib.rs
+++ b/spongefish/src/lib.rs
@@ -215,9 +215,7 @@ pub use codecs::ByteArray;
 pub use codecs::{Codec, Decoding, Encoding};
 pub use domain_separator::DomainSeparator;
 #[doc(hidden)]
-pub use domain_separator::{
-    protocol_id, protocol_id_literal, session_id, session_id_from_str, session_id_spec,
-};
+pub use domain_separator::{protocol_id, session_id, session_id_from_str};
 pub use duplex_sponge::{DuplexSponge, DuplexSpongeInterface, Permutation, Unit};
 pub use error::{VerificationError, VerificationResult};
 pub use io::{NargDeserialize, NargSerialize};

--- a/spongefish/src/narg_verifier.rs
+++ b/spongefish/src/narg_verifier.rs
@@ -174,6 +174,11 @@ impl<'a> VerifierState<'a, StdHash> {
     /// Initializes a verifier with `StdHash` as duplex sponge.
     #[must_use]
     pub fn new_std(protocol_id: &[u8; 64], session_id: &[u8; 64], narg_string: &'a [u8]) -> Self {
-        Self::new(protocol_id, session_id, narg_string)
+        let mut verifier_state = VerifierState {
+            duplex_sponge_state: StdHash::from_protocol_id(*protocol_id),
+            narg_string,
+        };
+        verifier_state.public_message(session_id);
+        verifier_state
     }
 }

--- a/spongefish/src/tests.rs
+++ b/spongefish/src/tests.rs
@@ -95,15 +95,15 @@ fn domain_separator_accepts_variable_sessions() {
 }
 
 #[test]
-fn protocol_id_literal_zero_pads_ascii() {
-    let protocol_id = crate::protocol_id_literal("sigma-proofs_Shake128_P256");
+fn protocol_id_zero_pads_ascii() {
+    let protocol_id = crate::protocol_id(core::format_args!("sigma-proofs_Shake128_P256"));
 
     assert_eq!(&protocol_id[..26], b"sigma-proofs_Shake128_P256",);
     assert!(protocol_id[26..].iter().all(|&byte| byte == 0));
 }
 
 #[test]
-fn session_id_spec_matches_rfc_construction() {
+fn session_id_matches_rfc_construction() {
     let mut initial_block = [0u8; 168];
     let domain = b"fiat-shamir/session-id";
     initial_block[..domain.len()].copy_from_slice(domain);
@@ -115,25 +115,25 @@ fn session_id_spec_matches_rfc_construction() {
     let mut expected_tail = [0u8; 32];
     reader.read(&mut expected_tail);
 
-    let session_id = crate::session_id_spec(b"discrete_logarithm");
+    let session_id = crate::session_id(core::format_args!("discrete_logarithm"));
     assert!(session_id[..32].iter().all(|&byte| byte == 0));
     assert_eq!(&session_id[32..], &expected_tail);
 }
 
 #[test]
-fn spec_transcript_initialization_matches_manual_shake128() {
-    let protocol = crate::protocol_id_literal("sigma-proofs_Shake128_P256");
-    let session = crate::session_id_spec(b"discrete_logarithm");
+fn std_transcript_initialization_matches_manual_shake128() {
+    let protocol = crate::protocol_id(core::format_args!("sigma-proofs_Shake128_P256"));
+    let session = crate::session_id(core::format_args!("discrete_logarithm"));
     let instance = [42u32, 7u32];
 
     let domain = crate::DomainSeparator::new(protocol)
         .session(session)
         .instance(&instance);
 
-    let mut prover = domain.std_prover_spec();
+    let mut prover = domain.std_prover();
     let challenge: [u8; 32] = prover.verifier_message();
 
-    let mut manual = crate::StdHash::from_iv(protocol);
+    let mut manual = crate::StdHash::from_protocol_id(protocol);
     manual.absorb(&session);
     let encoded_instance = instance.encode();
     manual.absorb(encoded_instance.as_ref());

--- a/spongefish/src/tests.rs
+++ b/spongefish/src/tests.rs
@@ -1,6 +1,9 @@
 use alloc::string::String;
 
 use rand::RngCore;
+use sha3::digest::{ExtendableOutput, Update, XofReader};
+
+use crate::{DuplexSpongeInterface, Encoding};
 
 #[test]
 fn prover_rng_emits_entropy() {
@@ -89,4 +92,52 @@ fn domain_separator_accepts_variable_sessions() {
         .session
         .expect("reference session missing");
     assert_eq!(literal_session, from_owned_ref);
+}
+
+#[test]
+fn protocol_id_literal_zero_pads_ascii() {
+    let protocol_id = crate::protocol_id_literal("sigma-proofs_Shake128_P256");
+
+    assert_eq!(&protocol_id[..26], b"sigma-proofs_Shake128_P256",);
+    assert!(protocol_id[26..].iter().all(|&byte| byte == 0));
+}
+
+#[test]
+fn session_id_spec_matches_rfc_construction() {
+    let mut initial_block = [0u8; 168];
+    let domain = b"fiat-shamir/session-id";
+    initial_block[..domain.len()].copy_from_slice(domain);
+
+    let mut shake = sha3::Shake128::default();
+    shake.update(&initial_block);
+    shake.update(b"discrete_logarithm");
+    let mut reader = shake.finalize_xof();
+    let mut expected_tail = [0u8; 32];
+    reader.read(&mut expected_tail);
+
+    let session_id = crate::session_id_spec(b"discrete_logarithm");
+    assert!(session_id[..32].iter().all(|&byte| byte == 0));
+    assert_eq!(&session_id[32..], &expected_tail);
+}
+
+#[test]
+fn spec_transcript_initialization_matches_manual_shake128() {
+    let protocol = crate::protocol_id_literal("sigma-proofs_Shake128_P256");
+    let session = crate::session_id_spec(b"discrete_logarithm");
+    let instance = [42u32, 7u32];
+
+    let domain = crate::DomainSeparator::new(protocol)
+        .session(session)
+        .instance(&instance);
+
+    let mut prover = domain.std_prover_spec();
+    let challenge: [u8; 32] = prover.verifier_message();
+
+    let mut manual = crate::StdHash::from_iv(protocol);
+    manual.absorb(&session);
+    let encoded_instance = instance.encode();
+    manual.absorb(encoded_instance.as_ref());
+    let expected = manual.squeeze_array::<32>();
+
+    assert_eq!(challenge, expected);
 }


### PR DESCRIPTION
This adds the RFC-oriented SHAKE128 transcript hooks needed to line up spongefish with the sigma-proofs/IETF test vectors without changing the existing default constructors.\n\nSummary:\n- add literal 64-byte protocol ID and RFC session ID helpers\n- add SHAKE128 initialization from an explicit IV\n- add spec-specific prover/verifier constructors for transcript setup\n- add regression tests for protocol ID padding, session ID derivation, and transcript initialization\n\nValidation:\n- cargo test -p spongefish tests:: --features sha3\n- cargo test -p spongefish --test test_spec test_all_duplex_sponge_vectors --features sha3\n- cargo clippy -p spongefish --tests --features sha3