### PR TITLE
chore(release): use shared v{{ version }} tags

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,7 +1,8 @@
 [workspace]
 changelog_update = false
 custom_minor_increment_regex = "^"
-git_release_enable = true
+git_release_enable = false
+git_tag_enable = false
 pr_branch_prefix = "release-plz-"
 pr_labels = ["release"]
 release_always = false
@@ -10,6 +11,9 @@ semver_check = false
 
 [[package]]
 name = "spongefish"
+git_release_enable = true
+git_tag_enable = true
+git_tag_name = "v{{ version }}"
 version_group = "workspace"
 
 [[package]]


### PR DESCRIPTION
Summary:
- make release-plz emit a single shared git tag named v{{ version }}
- stop workspace-wide git tag and git release creation for non-root crates
- keep the release behavior attached to the main spongefish package

Why:
The workspace should produce a single release tag like v0.3.0 rather than per-crate tags such as spongefish-v0.3.0.