### PR TITLE
fix arkworks codecs

### DIFF
--- a/spongefish/src/drivers/ark_ff_impl.rs
+++ b/spongefish/src/drivers/ark_ff_impl.rs
@@ -11,6 +11,15 @@ use crate::{
     VerificationResult,
 };
 
+fn parse_canonical_prime_field<F: PrimeField>(bytes: &[u8]) -> Option<F> {
+    let bits = bytes
+        .iter()
+        .flat_map(|byte| (0..8).rev().map(move |shift| (byte >> shift) & 1 == 1))
+        .collect::<Vec<_>>();
+    let bigint = F::BigInt::from_bits_be(&bits);
+    F::from_bigint(bigint)
+}
+
 // Make arkworks field elements a valid Unit type
 impl<C: ark_ff::FpConfig<N>, const N: usize> crate::Unit for Fp<C, N> {
     const ZERO: Self = C::ZERO;
@@ -55,7 +64,9 @@ macro_rules! impl_deserialize {
 
                 let mut base_elems = Vec::with_capacity(extension_degree);
                 for chunk in buf[..total_bytes].chunks_exact(base_field_size) {
-                    let elem = <<Self as Field>::BasePrimeField as PrimeField>::from_be_bytes_mod_order(chunk);
+                    let elem =
+                        parse_canonical_prime_field::<<Self as Field>::BasePrimeField>(chunk)
+                            .ok_or(VerificationError)?;
                     base_elems.push(elem);
                 }
                 debug_assert_eq!(base_elems.len(), extension_degree);
@@ -184,7 +195,9 @@ impl<F: Field> AsMut<[u8]> for DecodingFieldBuffer<F> {
 
 #[cfg(test)]
 mod test_ark_ff {
-    use crate::codecs::Encoding;
+    use ark_ff::{BigInteger, PrimeField};
+
+    use crate::{codecs::Encoding, io::NargDeserialize};
 
     fn encoding_testsuite<F: ark_ff::Field + Encoding<[u8]>>() {
         let first = F::from(10);
@@ -222,5 +235,14 @@ mod test_ark_ff {
         assert_eq!(bytes.len(), 32);
         assert!(bytes[..31].iter().all(|&byte| byte == 0));
         assert_eq!(bytes[31], 1);
+    }
+
+    #[test]
+    fn test_prime_field_deserialize_rejects_modulus() {
+        let modulus = ark_secp256k1::Fr::MODULUS.to_bytes_be();
+        let mut slice = modulus.as_slice();
+
+        assert!(ark_secp256k1::Fr::deserialize_from_narg(&mut slice).is_err());
+        assert_eq!(slice, modulus.as_slice());
     }
 }

--- a/spongefish/src/drivers/p3_baby_bear.rs
+++ b/spongefish/src/drivers/p3_baby_bear.rs
@@ -51,7 +51,7 @@ impl NargDeserialize for BabyBear {
 
         let mut repr = [0u8; 4];
         repr.copy_from_slice(&buf[..4]);
-        let value = u32::from_le_bytes(repr);
+        let value = u32::from_be_bytes(repr);
 
         // Check that the value is in the valid range
         if value >= Self::ORDER_U32 {
@@ -65,6 +65,6 @@ impl NargDeserialize for BabyBear {
 // Implement Encoding for BabyBear
 impl Encoding<[u8]> for BabyBear {
     fn encode(&self) -> impl AsRef<[u8]> {
-        self.as_canonical_u32().to_le_bytes()
+        self.as_canonical_u32().to_be_bytes()
     }
 }

--- a/spongefish/src/drivers/p3_koala_bear.rs
+++ b/spongefish/src/drivers/p3_koala_bear.rs
@@ -41,7 +41,7 @@ impl NargDeserialize for KoalaBear {
         }
         let mut repr = [0u8; 4];
         repr.copy_from_slice(&buf[..4]);
-        let value = u32::from_le_bytes(repr);
+        let value = u32::from_be_bytes(repr);
 
         // Check that the value is in the valid range
         if value >= Self::ORDER_U32 {
@@ -56,7 +56,7 @@ impl NargDeserialize for KoalaBear {
 // Implement Encoding for KoalaBear
 impl Encoding<[u8]> for KoalaBear {
     fn encode(&self) -> impl AsRef<[u8]> {
-        self.as_canonical_u32().to_le_bytes()
+        self.as_canonical_u32().to_be_bytes()
     }
 }
 
@@ -93,7 +93,7 @@ mod tests {
     #[test]
     fn test_koalabear_out_of_range() {
         // Try to deserialize a value larger than the modulus
-        let buf = KoalaBear::ORDER_U32.to_le_bytes();
+        let buf = KoalaBear::ORDER_U32.to_be_bytes();
         let result = KoalaBear::deserialize_from_narg(&mut &buf[..]);
         assert!(result.is_err());
     }

--- a/spongefish/src/drivers/p3_mersenne31.rs
+++ b/spongefish/src/drivers/p3_mersenne31.rs
@@ -32,7 +32,7 @@ impl NargDeserialize for Mersenne31 {
 
         let mut repr = [0u8; 4];
         repr.copy_from_slice(&buf[..4]);
-        let value = u32::from_le_bytes(repr);
+        let value = u32::from_be_bytes(repr);
 
         // Check that the value is in the valid range
         if value >= Self::ORDER_U32 {
@@ -45,6 +45,6 @@ impl NargDeserialize for Mersenne31 {
 
 impl Encoding<[u8]> for Mersenne31 {
     fn encode(&self) -> impl AsRef<[u8]> {
-        self.as_canonical_u32().to_le_bytes()
+        self.as_canonical_u32().to_be_bytes()
     }
 }

--- a/spongefish/src/drivers/tests.rs
+++ b/spongefish/src/drivers/tests.rs
@@ -104,18 +104,34 @@ where
     feature = "p3-mersenne-31"
 ))]
 #[test]
+fn p3_field_encoding_is_big_endian() {
+    use p3_baby_bear::BabyBear;
+    use p3_koala_bear::KoalaBear;
+    use p3_mersenne_31::Mersenne31;
+
+    assert_eq!(encoded_bytes(&BabyBear::new(1)), 1u32.to_be_bytes());
+    assert_eq!(encoded_bytes(&KoalaBear::new(1)), 1u32.to_be_bytes());
+    assert_eq!(encoded_bytes(&Mersenne31::new(1)), 1u32.to_be_bytes());
+}
+
+#[cfg(all(
+    feature = "p3-baby-bear",
+    feature = "p3-koala-bear",
+    feature = "p3-mersenne-31"
+))]
+#[test]
 fn p3_field_deserialize_advances_cursor() {
     use p3_baby_bear::BabyBear;
     use p3_koala_bear::KoalaBear;
     use p3_mersenne_31::Mersenne31;
 
-    let mut baby = &[1, 0, 0, 0, 9][..];
+    let mut baby = &[0, 0, 0, 1, 9][..];
     assert!(BabyBear::deserialize_from_narg(&mut baby).is_ok());
     assert_eq!(baby, &[9]);
-    let mut koala = &[1, 0, 0, 0, 9][..];
+    let mut koala = &[0, 0, 0, 1, 9][..];
     assert!(KoalaBear::deserialize_from_narg(&mut koala).is_ok());
     assert_eq!(koala, &[9]);
-    let mut mersenne = &[1, 0, 0, 0, 9][..];
+    let mut mersenne = &[0, 0, 0, 1, 9][..];
     assert!(Mersenne31::deserialize_from_narg(&mut mersenne).is_ok());
     assert_eq!(mersenne, &[9]);
 }
@@ -132,17 +148,17 @@ fn p3_field_deserialize_rejects_without_advancing_cursor() {
     use p3_koala_bear::KoalaBear;
     use p3_mersenne_31::Mersenne31;
 
-    let baby_buf = [BabyBear::ORDER_U32.to_le_bytes().as_slice(), &[9]].concat();
+    let baby_buf = [BabyBear::ORDER_U32.to_be_bytes().as_slice(), &[9]].concat();
     let mut baby = baby_buf.as_slice();
     assert!(BabyBear::deserialize_from_narg(&mut baby).is_err());
     assert_eq!(baby, baby_buf.as_slice());
 
-    let koala_buf = [KoalaBear::ORDER_U32.to_le_bytes().as_slice(), &[9]].concat();
+    let koala_buf = [KoalaBear::ORDER_U32.to_be_bytes().as_slice(), &[9]].concat();
     let mut koala = koala_buf.as_slice();
     assert!(KoalaBear::deserialize_from_narg(&mut koala).is_err());
     assert_eq!(koala, koala_buf.as_slice());
 
-    let mersenne_buf = [Mersenne31::ORDER_U32.to_le_bytes().as_slice(), &[9]].concat();
+    let mersenne_buf = [Mersenne31::ORDER_U32.to_be_bytes().as_slice(), &[9]].concat();
     let mut mersenne = mersenne_buf.as_slice();
     assert!(Mersenne31::deserialize_from_narg(&mut mersenne).is_err());
     assert_eq!(mersenne, mersenne_buf.as_slice());
@@ -155,8 +171,8 @@ fn array_deserialize_rejects_without_advancing_cursor() {
     use p3_field::PrimeField32;
 
     let input = [
-        1u32.to_le_bytes().as_slice(),
-        BabyBear::ORDER_U32.to_le_bytes().as_slice(),
+        1u32.to_be_bytes().as_slice(),
+        BabyBear::ORDER_U32.to_be_bytes().as_slice(),
         &[9],
     ]
     .concat();

--- a/spongefish/tests/derive_generics.rs
+++ b/spongefish/tests/derive_generics.rs
@@ -48,8 +48,8 @@ fn codec_derive_handles_generic_types() {
 #[cfg(feature = "p3-baby-bear")]
 fn derive_deserialize_rejects_without_advancing_cursor() {
     let input = [
-        1u32.to_le_bytes().as_slice(),
-        BabyBear::ORDER_U32.to_le_bytes().as_slice(),
+        1u32.to_be_bytes().as_slice(),
+        BabyBear::ORDER_U32.to_be_bytes().as_slice(),
         &[9],
     ]
     .concat();


### PR DESCRIPTION
Summary:
- split the release-safe codec fixes out of PR #82 onto a fresh branch from main
- make arkworks field deserialization reject non-canonical modulus encodings
- align BabyBear, KoalaBear, and Mersenne31 NARG encoding and decoding with big-endian I2OSP/OS2IP behavior

Not included:
- no crates.io patch override to git-sourced ark-ff or ark-serialize
- no unpublished SmallFp support or define_field-based tests

Validation:
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test -p spongefish --all-features
- cargo fmt