### PR TITLE
test: fix cargo test from spongfish dir by removing .cargo/config.toml

### DIFF
--- a/spongefish/.cargo/config.toml
+++ b/spongefish/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustdocflags = "--html-in-header doc/katex-header.html"


### PR DESCRIPTION
On `main` there the file `spongefish/.cargo/config.toml` specifies a flag to add KaTeX support to docs. This only applies when building from the `spongefish` directory, and not from the workspace root. It currently causes a test build failure when building from the `spongefish` directory.

I looked into this a bit, to see if I could get the KaTeX HTML inserted without causing issues, and to make the behavior when building from the workspace consistent with building from the crate directory. I couldn't find a good solution.

This PR removes the config file. On `docs.rs`, the KaTeX should still render (see https://docs.rs/spongefish/latest/spongefish/trait.NargDeserialize.html). Getting it to render locally can do accomplished with the following command.

```sh
RUSTDOCFLAGS="--html-in-header spongefish/doc/katex-header.html" cargo doc --no-deps --all-features
```
