### PR TITLE
#164: Consistent availability of verifier_messageX between ProverState and VerifierState

### DIFF
--- a/spongefish/src/narg_prover.rs
+++ b/spongefish/src/narg_prover.rs
@@ -249,7 +249,7 @@ where
         core::array::from_fn(|_| self.verifier_message())
     }
 
-    /// Reads `len` verifier messages `T` into a vector, each implementing `Encoding<[H::U]>`.
+    /// Returns a vector of uniformly-distributed verifier messages `[T; N]`.
     pub fn verifier_messages_vec<T: Decoding<[H::U]>>(&mut self, len: usize) -> Vec<T> {
         (0..len).map(|_| self.verifier_message()).collect()
     }

--- a/spongefish/src/narg_prover.rs
+++ b/spongefish/src/narg_prover.rs
@@ -249,7 +249,7 @@ where
         core::array::from_fn(|_| self.verifier_message())
     }
 
-    /// Returns a vector of uniformly-distributed verifier messages `[T; N]`.
+    /// Reads `len` verifier messages `T` into a vector, each implementing `Encoding<[H::U]>`.
     pub fn verifier_messages_vec<T: Decoding<[H::U]>>(&mut self, len: usize) -> Vec<T> {
         (0..len).map(|_| self.verifier_message()).collect()
     }

--- a/spongefish/src/narg_verifier.rs
+++ b/spongefish/src/narg_verifier.rs
@@ -64,6 +64,16 @@ impl<H: DuplexSpongeInterface> VerifierState<'_, H> {
         T::decode(buf)
     }
 
+    /// Returns a fixed-length array of uniformly-distributed verifier messages `[T; N]`.
+    pub fn verifier_messages<T: Decoding<[H::U]>, const N: usize>(&mut self) -> [T; N] {
+        core::array::from_fn(|_| self.verifier_message())
+    }
+
+    /// Reads `len` verifier messages `T` into a vector, each implementing `Encoding<[H::U]>`.
+    pub fn verifier_messages_vec<T: Decoding<[H::U]>>(&mut self, len: usize) -> Vec<T> {
+        (0..len).map(|_| self.verifier_message()).collect()
+    }
+
     /// Absorbs a slice of public messages.
     ///
     /// ```

--- a/spongefish/src/narg_verifier.rs
+++ b/spongefish/src/narg_verifier.rs
@@ -69,7 +69,7 @@ impl<H: DuplexSpongeInterface> VerifierState<'_, H> {
         core::array::from_fn(|_| self.verifier_message())
     }
 
-    /// Reads `len` verifier messages `T` into a vector, each implementing `Encoding<[H::U]>`.
+    /// Returns a vector of uniformly-distributed verifier messages `[T; N]`.
     pub fn verifier_messages_vec<T: Decoding<[H::U]>>(&mut self, len: usize) -> Vec<T> {
         (0..len).map(|_| self.verifier_message()).collect()
     }


### PR DESCRIPTION
Closes #164 

Additionally, I took the liberty to fix the comment of `verifier_messages_vec` in `ProverState`.