### PR TITLE
chore: release v0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "spongefish"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "ark-bls12-381",
  "ark-curve25519",
@@ -1775,7 +1775,7 @@ dependencies = [
 
 [[package]]
 name = "spongefish-circuit"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "p3-baby-bear",
  "p3-field",
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "spongefish-derive"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "spongefish-pow"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "blake3",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-version = "0.6.1"
+version = "0.6.2"
 repository = "https://github.com/arkworks-rs/spongefish"
 homepage = "https://github.com/arkworks-rs/spongefish"
 
@@ -76,7 +76,7 @@ sha2 = "0.11.0"
 sha3 = "=0.11.0-rc.9"
 spin = { version = "0.9", default-features = false, features = ["rwlock"] }
 # Intra-workspace dependencies
-spongefish = { version = "0.6.1", path = "spongefish" }
-spongefish-circuit = { version = "0.6.1", path = "circuit" }
-spongefish-derive = { version = "0.6.1", path = "derive" }
+spongefish = { version = "0.6.2", path = "spongefish" }
+spongefish-circuit = { version = "0.6.2", path = "circuit" }
+spongefish-derive = { version = "0.6.2", path = "derive" }
 zeroize = "^1.8.1"


### PR DESCRIPTION
This prepares the 0.6.2 maintenance release from the release/0.6 branch.\n\nIncludes:\n- backport of 4ee5f2b for portable Hash duplex sponge counters across pointer widths\n- release workflow support for release/** branches\n- workspace version bump from 0.6.1 to 0.6.2\n\nValidation:\n- cargo fmt --all -- --check\n- cargo test --workspace\n- cargo test --workspace --all-features\n- cargo test --workspace --no-default-features\n- cargo build --workspace --all-features --target wasm32-wasip1