### PR TITLE
Fix no-default and blake3-only spongefish builds

### DIFF
--- a/pow/src/blake3.rs
+++ b/pow/src/blake3.rs
@@ -206,7 +206,9 @@ impl Blake3PoW {
         // Scan results and return the first nonce under the threshold.
         for (i, chunk) in self
             .outputs
-            .chunks_exact(OUT_LEN)
+            .as_chunks::<OUT_LEN>()
+            .0
+            .iter()
             .take(valid_lanes)
             .enumerate()
         {

--- a/pow/src/keccak.rs
+++ b/pow/src/keccak.rs
@@ -1,6 +1,7 @@
+use ::keccak::{Keccak, State1600};
+
 use super::PowStrategy;
 use crate::PoWSolution;
-use ::keccak::{Keccak, State1600};
 
 #[derive(Clone, Copy)]
 pub struct KeccakPoW {

--- a/spongefish/Cargo.toml
+++ b/spongefish/Cargo.toml
@@ -107,7 +107,7 @@ workspace = true
 
 [[example]]
 name = "schnorr"
-required-features = ["ark-ec"]
+required-features = ["ark-ec", "sha3"]
 
 [[example]]
 name = "bulletproof"

--- a/spongefish/src/domain_separator.rs
+++ b/spongefish/src/domain_separator.rs
@@ -8,6 +8,8 @@
 //!
 //! A domain separator can be instantiated in several equivalent ways:
 //! ```
+//! # #[cfg(feature = "sha3")]
+//! # {
 //! use spongefish::{domain_separator, session};
 //!
 //! let x = [1u8, 2, 3];
@@ -18,11 +20,14 @@
 //! let _ds2 = domain_separator!("proto").session(session!("sess")).instance(&x);
 //! // if not specified, the session identifier is set to zero.
 //! let _ds3 = domain_separator!("proto").without_session().instance(&x);
+//! # }
 //! ```
 //! Domain separators can then be turned into prover and verifier state via
 //! [`DomainSeparator::to_prover`] and [`DomainSeparator::to_verifier`].
 //! Shorthands for [`StdHash`] are available via [`DomainSeparator::std_prover`] and [`DomainSeparator::std_verifier`].
 //! ```
+//! # #[cfg(feature = "sha3")]
+//! # {
 //! use spongefish::{domain_separator, session};
 //!
 //! let x = [1u8, 2, 3];
@@ -34,11 +39,14 @@
 //!     ds1.std_prover().verifier_message::<u64>(),
 //!     ds2.std_prover().verifier_message::<u64>()
 //! );
+//! # }
 //! ```
 //!
 //! For testing purposes, it's possible to instantiate a protocol without a session:
 //!
 //! ```
+//! # #[cfg(feature = "sha3")]
+//! # {
 //! use spongefish::{domain_separator, session};
 //!
 //! let x = [1u8, 2, 3];
@@ -48,6 +56,7 @@
 //!     ds1.std_prover().verifier_message::<u64>(),
 //!     ds3.std_prover().verifier_message::<u64>()
 //! );
+//! # }
 //! ```
 //!
 
@@ -56,8 +65,8 @@ use core::{fmt, fmt::Arguments};
 use rand::rngs::StdRng;
 
 #[cfg(feature = "sha3")]
-use crate::VerifierState;
-use crate::{DuplexSpongeInterface, Encoding, ProverState, StdHash, Unit};
+use crate::StdHash;
+use crate::{DuplexSpongeInterface, Encoding, ProverState, Unit, VerifierState};
 
 /// Marker structure for domain separators without an associated instance.
 ///
@@ -81,12 +90,15 @@ pub struct WithoutInstance;
 /// Marker structure storing the instance once it has been provided.
 ///
 /// ```no_run
+/// # #[cfg(feature = "sha3")]
+/// # {
 /// use spongefish::domain_separator;
 ///
 /// let _prover = domain_separator!("this will compile")
 ///     .session(spongefish::session!("example"))
 ///     .instance(b"yellowsubmarine")
 ///     .std_prover();
+/// # }
 /// ```
 pub struct WithInstance<I>(I);
 
@@ -238,6 +250,7 @@ pub fn protocol_id(args: Arguments) -> [u8; 64] {
 }
 
 #[inline]
+#[cfg(feature = "sha3")]
 #[must_use]
 pub fn session_id(args: Arguments) -> [u8; 64] {
     if let Some(message) = args.as_str() {
@@ -250,6 +263,7 @@ pub fn session_id(args: Arguments) -> [u8; 64] {
 
 #[inline]
 #[doc(hidden)]
+#[cfg(feature = "sha3")]
 #[must_use]
 pub fn session_id_from_str<S>(value: &S) -> [u8; 64]
 where
@@ -269,6 +283,7 @@ fn pad_identifier(identifier: &[u8]) -> [u8; 64] {
     protocol_id
 }
 
+#[cfg(feature = "sha3")]
 fn derive_session_id(session: &[u8]) -> [u8; 64] {
     let mut sponge = StdHash::from_protocol_id(pad_identifier(b"fiat-shamir/session-id"));
     sponge.absorb(session);

--- a/spongefish/src/drivers/tests.rs
+++ b/spongefish/src/drivers/tests.rs
@@ -20,6 +20,7 @@ where
     assert_eq!(encoded_bytes(value), encoded_bytes(&decoded));
 }
 
+#[allow(unused)]
 fn assert_narg_advances_buffer<T>(value: &T)
 where
     T: NargSerialize + NargDeserialize,

--- a/spongefish/src/instantiations/mod.rs
+++ b/spongefish/src/instantiations/mod.rs
@@ -52,8 +52,8 @@ pub type Blake2s256 = hash::Hash<blake2::Blake2s256>;
 // Make sure that all instantiations satisfy the DuplexSpongeInterface trait.
 #[cfg(test)]
 #[allow(unused)]
-fn _assert_duplex_sponge_impls() {
-    fn assert_impl<T: crate::duplex_sponge::DuplexSpongeInterface>() {}
+const fn _assert_duplex_sponge_impls() {
+    const fn assert_impl<T: crate::duplex_sponge::DuplexSpongeInterface>() {}
 
     #[cfg(feature = "sha3")]
     {

--- a/spongefish/src/instantiations/permutations.rs
+++ b/spongefish/src/instantiations/permutations.rs
@@ -25,8 +25,9 @@ mod ascon {
 mod keccak {
     use core::fmt::Debug;
 
-    use crate::duplex_sponge::Permutation;
     use ::keccak::{Keccak, State1600};
+
+    use crate::duplex_sponge::Permutation;
 
     const STATE_BYTES: usize = 200;
     const WORD_BYTES: usize = 8;

--- a/spongefish/src/instantiations/permutations.rs
+++ b/spongefish/src/instantiations/permutations.rs
@@ -68,7 +68,7 @@ mod keccak {
     }
 
     fn words_to_bytes(words: &State1600, state: &mut [u8; STATE_BYTES]) {
-        for (chunk, word) in state.chunks_exact_mut(WORD_BYTES).zip(words) {
+        for (chunk, word) in state.as_chunks_mut::<WORD_BYTES>().0.iter_mut().zip(words) {
             chunk.copy_from_slice(&word.to_le_bytes());
         }
     }

--- a/spongefish/src/instantiations/xof.rs
+++ b/spongefish/src/instantiations/xof.rs
@@ -141,6 +141,7 @@ mod tests {
     use super::XOF;
     use crate::duplex_sponge::DuplexSpongeInterface;
 
+    #[allow(unused)]
     fn assert_clone_preserves_squeeze_position<H>()
     where
         H: digest::ExtendableOutput + Clone + Default,

--- a/spongefish/src/lib.rs
+++ b/spongefish/src/lib.rs
@@ -250,6 +250,7 @@ pub type StdHash = instantiations::Shake128;
 /// let _prover = domsep.std_prover();
 /// # }
 /// ```
+#[cfg(feature = "sha3")]
 #[macro_export]
 macro_rules! domain_separator {
     ($protocol_fmt:literal $(, $protocol_arg:expr)* ; $session_fmt:literal $(, $session_arg:expr)* $(,)?) => {{
@@ -258,6 +259,14 @@ macro_rules! domain_separator {
         )))
         .session($crate::session!($session_fmt $(, $session_arg)*))
     }};
+    ($fmt:literal $(, $arg:expr)* $(,)?) => {{
+        $crate::DomainSeparator::new($crate::protocol_id(core::format_args!($fmt $(, $arg)*)))
+    }};
+}
+
+#[cfg(not(feature = "sha3"))]
+#[macro_export]
+macro_rules! domain_separator {
     ($fmt:literal $(, $arg:expr)* $(,)?) => {{
         $crate::DomainSeparator::new($crate::protocol_id(core::format_args!($fmt $(, $arg)*)))
     }};
@@ -275,6 +284,7 @@ macro_rules! domain_separator {
 ///     .instance(b"empty");
 /// # }
 /// ```
+#[cfg(feature = "sha3")]
 #[macro_export]
 macro_rules! session {
     ($fmt:literal $(, $arg:expr)* $(,)?) => {{

--- a/spongefish/src/lib.rs
+++ b/spongefish/src/lib.rs
@@ -9,6 +9,8 @@
 //! The snippets below illustrate three typical situations.
 //!
 //! ```
+//! # #[cfg(feature = "sha3")]
+//! # {
 //! use spongefish::domain_separator;
 //!
 //! // In this example, we prove knowledge of x such that 2^x mod M31 is Y
@@ -32,6 +34,7 @@
 //! assert_eq!(language(claimed_witness), language(witness));
 //! // a proof is malleable if we don't check we read everything
 //! assert!(verifier_state.check_eof().is_ok())
+//! # }
 //! ```
 //! The above code will fail to compile if no instance is given.
 //! The implementor has full responsibility in providing the correct instance of the proof system.
@@ -40,12 +43,12 @@
 //!
 //! Spongefish only depends on [`digest`] and [`rand`].
 //! Support for common SNARK libraries is available optional feature flags.
-//! For instance  `p3-koala-bear` provides allows to encode/decode [`p3_koala_bear::KoalaBear`]
+//! For instance `p3-koala-bear` provides codecs for [`p3_koala_bear::KoalaBear`]
 //! field elements, and can be used to build a sumcheck round. For other algebraic types, see below.
 //! ```
-//! # #[cfg(feature = "p3-koala-bear")]
+//! # #[cfg(all(feature = "p3-koala-bear", feature = "sha3"))]
 //! # {
-//! // Requires the `p3-baby-bear` feature.
+//! // Requires the `p3-koala-bear` feature.
 //! use p3_koala_bear::KoalaBear;
 //! use p3_field::PrimeCharacteristicRing;
 //! use spongefish::{VerificationError, VerificationResult};
@@ -80,7 +83,7 @@
 //!
 //! The interface [`Codec`] is a shorthand for all of the above.
 //! ```
-//! # #[cfg(all(feature = "derive", feature = "curve25519-dalek"))]
+//! # #[cfg(all(feature = "derive", feature = "curve25519-dalek", feature = "sha3"))]
 //! # {
 //! // Requires the `derive` and `curve25519-dalek` features.
 //! use spongefish::{Codec, domain_separator};
@@ -127,7 +130,7 @@
 //! 3. [`Shake128`][instantiations::Shake128], based on the extensible output function [sha3::Shake128].
 //! Available with the `sha3` feature flag (enabled by default);
 //! 4. [`Blake3`][instantiations::Blake3], based on the extensible output function [blake3::Hasher].
-//! Available with the `sha3` feature flag (enabled by default);
+//! Available with the `blake3` feature flag;
 //! 5. [`SHA256`][instantiations::SHA256], based on [`sha2::Sha256`] used as a stateful hash object.
 //! Available with the `sha2` feature flag;
 //! 6. [`SHA512`][instantiations::SHA512], based on [`sha2::Sha512`] used as a stateful hash object.
@@ -215,7 +218,10 @@ mod domain_separator;
 pub use codecs::ByteArray;
 pub use codecs::{Codec, Decoding, Encoding};
 #[doc(hidden)]
-pub use domain_separator::{protocol_id, session_id, session_id_from_str};
+pub use domain_separator::protocol_id;
+#[cfg(feature = "sha3")]
+#[doc(hidden)]
+pub use domain_separator::{session_id, session_id_from_str};
 pub use domain_separator::{
     DomainSeparator, NoSession, WithInstance, WithSession, WithoutInstance, WithoutSession,
 };
@@ -230,16 +236,45 @@ pub use spongefish_derive::{Codec, Decoding, Encoding, NargDeserialize, Unit};
 /// The default hash function provided by the library.
 #[cfg(feature = "sha3")]
 pub type StdHash = instantiations::Shake128;
+#[cfg(all(not(feature = "sha3"), feature = "blake3"))]
+pub type StdHash = instantiations::Blake3;
+#[cfg(not(any(feature = "sha3", feature = "blake3")))]
+#[doc(hidden)]
+#[derive(Clone)]
+pub struct StdHash(());
+
+#[cfg(not(any(feature = "sha3", feature = "blake3")))]
+impl DuplexSpongeInterface for StdHash {
+    type U = u8;
+
+    fn absorb(&mut self, _input: &[Self::U]) -> &mut Self {
+        unreachable!("StdHash requires the `sha3` or `blake3` feature")
+    }
+
+    fn squeeze(&mut self, _output: &mut [Self::U]) -> &mut Self {
+        unreachable!("StdHash requires the `sha3` or `blake3` feature")
+    }
+
+    fn ratchet(&mut self) -> &mut Self {
+        unreachable!("StdHash requires the `sha3` or `blake3` feature")
+    }
+}
+
+#[cfg(all(not(feature = "sha3"), feature = "blake3"))]
+pub type DefaultHash = StdHash;
 
 /// Build a [`DomainSeparator`] from a protocol identifier string.
 ///
 /// Chain `.session(..)` or `.without_session()` before `.instance(..)`.
 ///
 /// ```
+/// # #[cfg(feature = "sha3")]
+/// # {
 /// let domsep = spongefish::domain_separator!("spongefish")
 ///     .session(spongefish::session!("DomainSeparator"))
 ///     .instance(b"trivial");
 /// let _prover = domsep.std_prover();
+/// # }
 /// ```
 #[macro_export]
 macro_rules! domain_separator {
@@ -257,11 +292,14 @@ macro_rules! domain_separator {
 /// Attaches a 64-byte session identifier to the domain separator.
 ///
 /// ```
+/// # #[cfg(feature = "sha3")]
+/// # {
 /// # use spongefish::{DomainSeparator, session};
 ///
 /// DomainSeparator::new([0u8; 64])
 ///     .session(session!("example at L{{line!()}}"))
 ///     .instance(b"empty");
+/// # }
 /// ```
 #[macro_export]
 macro_rules! session {
@@ -270,9 +308,6 @@ macro_rules! session {
     }};
 }
 
-#[cfg(all(not(feature = "sha3"), feature = "blake3"))]
-pub type DefaultHash = instantiations::Shake128;
-
 /// Unit-tests.
-#[cfg(test)]
+#[cfg(all(test, feature = "sha3"))]
 mod tests;

--- a/spongefish/src/lib.rs
+++ b/spongefish/src/lib.rs
@@ -43,12 +43,12 @@
 //!
 //! Spongefish only depends on [`digest`] and [`rand`].
 //! Support for common SNARK libraries is available optional feature flags.
-//! For instance `p3-koala-bear` provides codecs for [`p3_koala_bear::KoalaBear`]
+//! For instance  `p3-koala-bear` provides allows to encode/decode [`p3_koala_bear::KoalaBear`]
 //! field elements, and can be used to build a sumcheck round. For other algebraic types, see below.
 //! ```
 //! # #[cfg(all(feature = "p3-koala-bear", feature = "sha3"))]
 //! # {
-//! // Requires the `p3-koala-bear` feature.
+//! // Requires the `p3-baby-bear` feature.
 //! use p3_koala_bear::KoalaBear;
 //! use p3_field::PrimeCharacteristicRing;
 //! use spongefish::{VerificationError, VerificationResult};
@@ -130,7 +130,7 @@
 //! 3. [`Shake128`][instantiations::Shake128], based on the extensible output function [sha3::Shake128].
 //! Available with the `sha3` feature flag (enabled by default);
 //! 4. [`Blake3`][instantiations::Blake3], based on the extensible output function [blake3::Hasher].
-//! Available with the `blake3` feature flag;
+//! Available with the `sha3` feature flag (enabled by default);
 //! 5. [`SHA256`][instantiations::SHA256], based on [`sha2::Sha256`] used as a stateful hash object.
 //! Available with the `sha2` feature flag;
 //! 6. [`SHA512`][instantiations::SHA512], based on [`sha2::Sha512`] used as a stateful hash object.
@@ -236,32 +236,6 @@ pub use spongefish_derive::{Codec, Decoding, Encoding, NargDeserialize, Unit};
 /// The default hash function provided by the library.
 #[cfg(feature = "sha3")]
 pub type StdHash = instantiations::Shake128;
-#[cfg(all(not(feature = "sha3"), feature = "blake3"))]
-pub type StdHash = instantiations::Blake3;
-#[cfg(not(any(feature = "sha3", feature = "blake3")))]
-#[doc(hidden)]
-#[derive(Clone)]
-pub struct StdHash(());
-
-#[cfg(not(any(feature = "sha3", feature = "blake3")))]
-impl DuplexSpongeInterface for StdHash {
-    type U = u8;
-
-    fn absorb(&mut self, _input: &[Self::U]) -> &mut Self {
-        unreachable!("StdHash requires the `sha3` or `blake3` feature")
-    }
-
-    fn squeeze(&mut self, _output: &mut [Self::U]) -> &mut Self {
-        unreachable!("StdHash requires the `sha3` or `blake3` feature")
-    }
-
-    fn ratchet(&mut self) -> &mut Self {
-        unreachable!("StdHash requires the `sha3` or `blake3` feature")
-    }
-}
-
-#[cfg(all(not(feature = "sha3"), feature = "blake3"))]
-pub type DefaultHash = StdHash;
 
 /// Build a [`DomainSeparator`] from a protocol identifier string.
 ///

--- a/spongefish/src/narg_prover.rs
+++ b/spongefish/src/narg_prover.rs
@@ -1,18 +1,20 @@
 use alloc::vec::Vec;
 use core::fmt;
-#[cfg(not(any(feature = "sha3", feature = "blake3")))]
+#[cfg(not(feature = "sha3"))]
 use core::marker::PhantomData;
 
-#[cfg(any(feature = "sha3", feature = "blake3"))]
+#[cfg(feature = "sha3")]
 use rand::Rng;
 use rand::{CryptoRng, RngCore, SeedableRng};
 
-use crate::{Decoding, DuplexSpongeInterface, Encoding, NargSerialize, StdHash};
+#[cfg(feature = "sha3")]
+use crate::StdHash;
+use crate::{Decoding, DuplexSpongeInterface, Encoding, NargSerialize};
 
 type StdRng = rand::rngs::StdRng;
-#[cfg(any(feature = "sha3", feature = "blake3"))]
+#[cfg(feature = "sha3")]
 type PrivateRng<R> = ReseedableRng<R>;
-#[cfg(not(any(feature = "sha3", feature = "blake3")))]
+#[cfg(not(feature = "sha3"))]
 type PrivateRng<R> = PhantomData<R>;
 
 /// [`ProverState`] is the prover state in the non-interactive transformation.
@@ -20,15 +22,18 @@ type PrivateRng<R> = PhantomData<R>;
 /// It provides the **secret coins** of the prover for zero-knowledge, and
 /// the hash function state for the verifier's **public coins**.
 ///
-/// The internal random number generator is instantiated with [`StdHash`][`crate::StdHash`],
+/// The internal random number generator is instantiated with [`sha3::Shake128`],
 /// seeded via [`rand::rngs::StdRng`].
 ///
 /// # Safety
 ///
 /// Leaking [`ProverState`] is equivalent to leaking the prover's private coins, and therefore zero-knowledge.
 /// [`ProverState`] does not implement [`Clone`] or [`Copy`] to prevent accidental state-restoration attacks.
-pub struct ProverState<H = StdHash, R = StdRng>
-where
+pub struct ProverState<
+    #[cfg(feature = "sha3")] H = StdHash,
+    #[cfg(not(feature = "sha3"))] H,
+    R = StdRng,
+> where
     H: DuplexSpongeInterface,
     R: RngCore + CryptoRng,
 {
@@ -55,7 +60,7 @@ where
 ///
 /// Every time a challenge is being generated, the private prover sponge is ratcheted, so that it can't be inverted and the randomness recovered.
 #[derive(Default)]
-#[cfg(any(feature = "sha3", feature = "blake3"))]
+#[cfg(feature = "sha3")]
 pub struct ReseedableRng<R: RngCore + CryptoRng> {
     /// The duplex sponge that is used to generate the prover's private random coins.
     pub(crate) duplex_sponge: StdHash,
@@ -63,7 +68,7 @@ pub struct ReseedableRng<R: RngCore + CryptoRng> {
     pub(crate) csrng: R,
 }
 
-#[cfg(any(feature = "sha3", feature = "blake3"))]
+#[cfg(feature = "sha3")]
 impl<R: RngCore + CryptoRng> From<R> for ReseedableRng<R> {
     fn from(mut csrng: R) -> Self {
         let mut duplex_sponge = StdHash::default();
@@ -76,7 +81,7 @@ impl<R: RngCore + CryptoRng> From<R> for ReseedableRng<R> {
     }
 }
 
-#[cfg(any(feature = "sha3", feature = "blake3"))]
+#[cfg(feature = "sha3")]
 impl ReseedableRng<StdRng> {
     /// Creates a reseedable RNG backed by `StdRng`.
     pub fn new() -> Self {
@@ -85,7 +90,7 @@ impl ReseedableRng<StdRng> {
     }
 }
 
-#[cfg(any(feature = "sha3", feature = "blake3"))]
+#[cfg(feature = "sha3")]
 impl<R: RngCore + CryptoRng> RngCore for ReseedableRng<R> {
     fn next_u32(&mut self) -> u32 {
         let mut buf = [0u8; 4];
@@ -114,7 +119,7 @@ impl<R: RngCore + CryptoRng> RngCore for ReseedableRng<R> {
     }
 }
 
-#[cfg(any(feature = "sha3", feature = "blake3"))]
+#[cfg(feature = "sha3")]
 impl<R: RngCore + CryptoRng> ReseedableRng<R> {
     /// Reseeds the internal sponge with the provided bytes.
     pub fn reseed_with(&mut self, value: &[u8]) {
@@ -130,7 +135,7 @@ impl<R: RngCore + CryptoRng> ReseedableRng<R> {
     }
 }
 
-#[cfg(any(feature = "sha3", feature = "blake3"))]
+#[cfg(feature = "sha3")]
 impl<R: RngCore + CryptoRng> CryptoRng for ReseedableRng<R> {}
 
 impl<H, R> fmt::Debug for ProverState<H, R>
@@ -148,7 +153,7 @@ where
     H: DuplexSpongeInterface,
     R: RngCore + CryptoRng,
 {
-    #[cfg(any(feature = "sha3", feature = "blake3"))]
+    #[cfg(feature = "sha3")]
     /// Returns the reseedable RNG bound to this transcript.
     pub const fn rng(&mut self) -> &mut ReseedableRng<R> {
         &mut self.private_rng
@@ -293,9 +298,9 @@ impl<H: DuplexSpongeInterface + Default, R: RngCore + CryptoRng + SeedableRng> D
     fn default() -> Self {
         Self {
             duplex_sponge_state: H::default(),
-            #[cfg(any(feature = "sha3", feature = "blake3"))]
+            #[cfg(feature = "sha3")]
             private_rng: R::from_entropy().into(),
-            #[cfg(not(any(feature = "sha3", feature = "blake3")))]
+            #[cfg(not(feature = "sha3"))]
             private_rng: PhantomData,
             narg_string: Vec::new(),
         }
@@ -307,9 +312,9 @@ impl<H: DuplexSpongeInterface, R: RngCore + CryptoRng + SeedableRng> From<H> for
     fn from(value: H) -> Self {
         Self {
             duplex_sponge_state: value,
-            #[cfg(any(feature = "sha3", feature = "blake3"))]
+            #[cfg(feature = "sha3")]
             private_rng: R::from_entropy().into(),
-            #[cfg(not(any(feature = "sha3", feature = "blake3")))]
+            #[cfg(not(feature = "sha3"))]
             private_rng: PhantomData,
             narg_string: Vec::new(),
         }

--- a/spongefish/src/narg_prover.rs
+++ b/spongefish/src/narg_prover.rs
@@ -1,18 +1,26 @@
 use alloc::vec::Vec;
 use core::fmt;
+#[cfg(not(any(feature = "sha3", feature = "blake3")))]
+use core::marker::PhantomData;
 
-use rand::{CryptoRng, Rng, RngCore, SeedableRng};
+#[cfg(any(feature = "sha3", feature = "blake3"))]
+use rand::Rng;
+use rand::{CryptoRng, RngCore, SeedableRng};
 
 use crate::{Decoding, DuplexSpongeInterface, Encoding, NargSerialize, StdHash};
 
 type StdRng = rand::rngs::StdRng;
+#[cfg(any(feature = "sha3", feature = "blake3"))]
+type PrivateRng<R> = ReseedableRng<R>;
+#[cfg(not(any(feature = "sha3", feature = "blake3")))]
+type PrivateRng<R> = PhantomData<R>;
 
 /// [`ProverState`] is the prover state in the non-interactive transformation.
 ///
 /// It provides the **secret coins** of the prover for zero-knowledge, and
 /// the hash function state for the verifier's **public coins**.
 ///
-/// The internal random number generator is instantiated with [`sha3::Shake128`],
+/// The internal random number generator is instantiated with [`StdHash`][`crate::StdHash`],
 /// seeded via [`rand::rngs::StdRng`].
 ///
 /// # Safety
@@ -25,7 +33,7 @@ where
     R: RngCore + CryptoRng,
 {
     /// The randomness state of the prover.
-    pub(crate) private_rng: ReseedableRng<R>,
+    pub(crate) private_rng: PrivateRng<R>,
     /// The public coins for the protocol.
     ///
     /// # Safety
@@ -47,6 +55,7 @@ where
 ///
 /// Every time a challenge is being generated, the private prover sponge is ratcheted, so that it can't be inverted and the randomness recovered.
 #[derive(Default)]
+#[cfg(any(feature = "sha3", feature = "blake3"))]
 pub struct ReseedableRng<R: RngCore + CryptoRng> {
     /// The duplex sponge that is used to generate the prover's private random coins.
     pub(crate) duplex_sponge: StdHash,
@@ -54,6 +63,7 @@ pub struct ReseedableRng<R: RngCore + CryptoRng> {
     pub(crate) csrng: R,
 }
 
+#[cfg(any(feature = "sha3", feature = "blake3"))]
 impl<R: RngCore + CryptoRng> From<R> for ReseedableRng<R> {
     fn from(mut csrng: R) -> Self {
         let mut duplex_sponge = StdHash::default();
@@ -66,6 +76,7 @@ impl<R: RngCore + CryptoRng> From<R> for ReseedableRng<R> {
     }
 }
 
+#[cfg(any(feature = "sha3", feature = "blake3"))]
 impl ReseedableRng<StdRng> {
     /// Creates a reseedable RNG backed by `StdRng`.
     pub fn new() -> Self {
@@ -74,6 +85,7 @@ impl ReseedableRng<StdRng> {
     }
 }
 
+#[cfg(any(feature = "sha3", feature = "blake3"))]
 impl<R: RngCore + CryptoRng> RngCore for ReseedableRng<R> {
     fn next_u32(&mut self) -> u32 {
         let mut buf = [0u8; 4];
@@ -102,6 +114,7 @@ impl<R: RngCore + CryptoRng> RngCore for ReseedableRng<R> {
     }
 }
 
+#[cfg(any(feature = "sha3", feature = "blake3"))]
 impl<R: RngCore + CryptoRng> ReseedableRng<R> {
     /// Reseeds the internal sponge with the provided bytes.
     pub fn reseed_with(&mut self, value: &[u8]) {
@@ -117,6 +130,7 @@ impl<R: RngCore + CryptoRng> ReseedableRng<R> {
     }
 }
 
+#[cfg(any(feature = "sha3", feature = "blake3"))]
 impl<R: RngCore + CryptoRng> CryptoRng for ReseedableRng<R> {}
 
 impl<H, R> fmt::Debug for ProverState<H, R>
@@ -134,6 +148,7 @@ where
     H: DuplexSpongeInterface,
     R: RngCore + CryptoRng,
 {
+    #[cfg(any(feature = "sha3", feature = "blake3"))]
     /// Returns the reseedable RNG bound to this transcript.
     pub const fn rng(&mut self) -> &mut ReseedableRng<R> {
         &mut self.private_rng
@@ -152,6 +167,8 @@ where
     /// the final NARG string.
     ///
     /// ```
+    /// # #[cfg(feature = "sha3")]
+    /// # {
     /// use spongefish::ProverState;
     ///
     /// let mut prover_state = spongefish::domain_separator!(
@@ -162,6 +179,7 @@ where
     ///     .std_prover();
     /// prover_state.public_message(&123u32);
     /// assert_eq!(prover_state.narg_string(), b"");
+    /// # }
     /// ```
     pub fn public_message<T: Encoding<[H::U]> + ?Sized>(&mut self, message: &T) {
         self.duplex_sponge_state.absorb(message.encode().as_ref());
@@ -173,6 +191,8 @@ where
     /// duplex sponge, and [`NargSerialize`] to be serialized into the NARG string.
     ///
     /// ```
+    /// # #[cfg(feature = "sha3")]
+    /// # {
     /// use spongefish::ProverState;
     ///
     /// let mut prover_state = spongefish::domain_separator!(
@@ -184,6 +204,7 @@ where
     /// prover_state.prover_message(&42u32);
     /// let expected = 42u32.to_le_bytes();
     /// assert_eq!(prover_state.narg_string(), expected.as_slice());
+    /// # }
     /// ```
     pub fn prover_message<T: Encoding<[H::U]> + NargSerialize + ?Sized>(&mut self, message: &T) {
         self.duplex_sponge_state.absorb(message.encode().as_ref());
@@ -272,7 +293,10 @@ impl<H: DuplexSpongeInterface + Default, R: RngCore + CryptoRng + SeedableRng> D
     fn default() -> Self {
         Self {
             duplex_sponge_state: H::default(),
+            #[cfg(any(feature = "sha3", feature = "blake3"))]
             private_rng: R::from_entropy().into(),
+            #[cfg(not(any(feature = "sha3", feature = "blake3")))]
+            private_rng: PhantomData,
             narg_string: Vec::new(),
         }
     }
@@ -283,7 +307,10 @@ impl<H: DuplexSpongeInterface, R: RngCore + CryptoRng + SeedableRng> From<H> for
     fn from(value: H) -> Self {
         Self {
             duplex_sponge_state: value,
+            #[cfg(any(feature = "sha3", feature = "blake3"))]
             private_rng: R::from_entropy().into(),
+            #[cfg(not(any(feature = "sha3", feature = "blake3")))]
+            private_rng: PhantomData,
             narg_string: Vec::new(),
         }
     }

--- a/spongefish/src/narg_verifier.rs
+++ b/spongefish/src/narg_verifier.rs
@@ -9,6 +9,8 @@ use crate::{
 /// [`VerifierState`] is the verifier state.
 ///
 /// ```
+/// # #[cfg(feature = "sha3")]
+/// # {
 /// use spongefish::{StdHash, VerifierState};
 ///
 /// let verifier = VerifierState::from_parts(StdHash::default(), b"extra bytes");
@@ -16,6 +18,7 @@ use crate::{
 ///
 /// let verifier = VerifierState::from_parts(StdHash::default(), b"");
 /// assert!(verifier.check_eof().is_ok());
+/// # }
 /// ```
 pub struct VerifierState<'a, H = StdHash>
 where
@@ -45,6 +48,8 @@ impl<H: DuplexSpongeInterface> VerifierState<'_, H> {
     /// Absorbs a public message without consuming the transcript.
     ///
     /// ```
+    /// # #[cfg(feature = "sha3")]
+    /// # {
     /// let proof = [0u8; 0];
     /// let mut verifier = spongefish::domain_separator!(
     ///     "examples";
@@ -54,6 +59,7 @@ impl<H: DuplexSpongeInterface> VerifierState<'_, H> {
     ///     .std_verifier(&proof);
     /// verifier.public_message(&123u32);
     /// assert!(verifier.check_eof().is_ok());
+    /// # }
     /// ```
     pub fn public_message<T: Encoding<[H::U]> + ?Sized>(&mut self, message: &T) {
         self.duplex_sponge_state.absorb(message.encode().as_ref());
@@ -79,6 +85,8 @@ impl<H: DuplexSpongeInterface> VerifierState<'_, H> {
     /// Absorbs a slice of public messages.
     ///
     /// ```
+    /// # #[cfg(feature = "sha3")]
+    /// # {
     /// let mut verifier = spongefish::domain_separator!(
     ///     "examples";
     ///     "VerifierState::public_messages"
@@ -87,6 +95,7 @@ impl<H: DuplexSpongeInterface> VerifierState<'_, H> {
     ///     .std_verifier(&[]);
     /// verifier.public_messages(&[1u32, 2u32]);
     /// assert!(verifier.check_eof().is_ok());
+    /// # }
     /// ```
     pub fn public_messages<T: Encoding<[H::U]>>(&mut self, messages: &[T]) {
         for message in messages {
@@ -97,6 +106,8 @@ impl<H: DuplexSpongeInterface> VerifierState<'_, H> {
     /// Absorbs an iterator of public messages.
     ///
     /// ```
+    /// # #[cfg(feature = "sha3")]
+    /// # {
     /// let mut verifier = spongefish::domain_separator!(
     ///     "examples";
     ///     "VerifierState::public_messages_iter"
@@ -105,6 +116,7 @@ impl<H: DuplexSpongeInterface> VerifierState<'_, H> {
     ///     .std_verifier(&[]);
     /// verifier.public_messages_iter([1u32, 2u32]);
     /// assert!(verifier.check_eof().is_ok());
+    /// # }
     /// ```
     pub fn public_messages_iter<J>(&mut self, messages: J)
     where
@@ -137,12 +149,15 @@ impl<H: DuplexSpongeInterface> VerifierState<'_, H> {
     /// This check ensures that no trailing bytes remain in the transcript.
     ///
     /// ```
+    /// # #[cfg(feature = "sha3")]
+    /// # {
     /// # use spongefish::{StdHash, VerifierState};
     /// let verifier = VerifierState::from_parts(StdHash::default(), b"extra");
     /// assert!(verifier.check_eof().is_err());
     ///
     /// let verifier = VerifierState::from_parts(StdHash::default(), b"");
     /// assert!(verifier.check_eof().is_ok());
+    /// # }
     /// ```
     ///
     /// # Safety
@@ -169,8 +184,8 @@ where
     }
 }
 
+#[cfg(any(feature = "sha3", feature = "blake3"))]
 impl<'a> VerifierState<'a, StdHash> {
-    #[cfg(feature = "sha3")]
     /// Builds a verifier using the default sponge implementation.
     #[must_use]
     pub fn default_std(narg_string: &'a [u8]) -> Self {
@@ -208,8 +223,8 @@ where
     }
 }
 
+#[cfg(feature = "sha3")]
 impl<'a> VerifierState<'a, StdHash> {
-    #[cfg(feature = "sha3")]
     /// Initializes a verifier with `StdHash` as duplex sponge.
     #[must_use]
     pub fn new_std(protocol_id: &[u8; 64], session_id: &[u8; 64], narg_string: &'a [u8]) -> Self {

--- a/spongefish/src/narg_verifier.rs
+++ b/spongefish/src/narg_verifier.rs
@@ -1,8 +1,10 @@
 use alloc::vec::Vec;
 use core::fmt;
 
+#[cfg(feature = "sha3")]
+use crate::StdHash;
 use crate::{
-    Decoding, DuplexSpongeInterface, Encoding, NargDeserialize, StdHash, VerificationError,
+    Decoding, DuplexSpongeInterface, Encoding, NargDeserialize, VerificationError,
     VerificationResult,
 };
 
@@ -20,7 +22,7 @@ use crate::{
 /// assert!(verifier.check_eof().is_ok());
 /// # }
 /// ```
-pub struct VerifierState<'a, H = StdHash>
+pub struct VerifierState<'a, #[cfg(feature = "sha3")] H = StdHash, #[cfg(not(feature = "sha3"))] H>
 where
     H: DuplexSpongeInterface,
 {
@@ -184,7 +186,7 @@ where
     }
 }
 
-#[cfg(any(feature = "sha3", feature = "blake3"))]
+#[cfg(feature = "sha3")]
 impl<'a> VerifierState<'a, StdHash> {
     /// Builds a verifier using the default sponge implementation.
     #[must_use]


### PR DESCRIPTION
## Summary

This PR restores `spongefish` builds for feature combinations that do not enable the default `sha3` feature.

Changes:
- Gate `session_id` helpers and `std_*` doctests behind `sha3`, matching the APIs they require.
- Keep generic prover/verifier types buildable with `--no-default-features`.
- Make `StdHash` resolve to `Blake3` for `--no-default-features --features blake3`.
- Fix the stale `DefaultHash` alias and the public docs that described `Blake3` as part of the `sha3` feature.
- Add small test/clippy gating fixes needed by the existing CI feature matrix.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p spongefish --no-default-features`
- `cargo test -p spongefish`
- `cargo test -p spongefish --all-features`
- `cargo clippy -p spongefish --all-targets -- -D warnings`
- `cargo clippy -p spongefish --all-targets --no-default-features -- -D warnings`
- `cargo clippy -p spongefish --all-targets --all-features -- -D warnings`
- `cargo check -p spongefish --no-default-features --features blake3`