### PR TITLE
chore(deps)!: update rand and cryptography dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,9 +292,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base16ct"
-version = "0.2.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64"
@@ -396,8 +396,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
 dependencies = [
- "ff",
- "group",
+ "ff 0.13.1",
+ "group 0.13.0",
  "pairing",
  "rand_core 0.6.4",
  "subtle",
@@ -473,6 +473,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -584,6 +595,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,12 +645,16 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.5"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
- "generic-array",
- "rand_core 0.6.4",
+ "cpubits",
+ "ctutils",
+ "getrandom",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
  "subtle",
  "zeroize",
 ]
@@ -654,7 +675,9 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
+ "getrandom",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -664,16 +687,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+ "subtle",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "fiat-crypto",
  "rustc_version",
@@ -694,11 +718,11 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.10"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid 0.10.2",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -745,16 +769,17 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.9"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest 0.11.3",
  "elliptic-curve",
  "rfc6979",
  "signature",
  "spki",
+ "zeroize",
 ]
 
 [[package]]
@@ -777,19 +802,20 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.8"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
+ "crypto-common 0.2.1",
+ "digest 0.11.3",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
  "pem-rfc7468",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "sec1",
  "subtle",
  "zeroize",
@@ -839,10 +865,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "fiat-crypto"
-version = "0.2.9"
+name = "ff"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -927,18 +963,18 @@ checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "r-efi",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -947,8 +983,19 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff 0.14.0",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -988,20 +1035,22 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.10.7",
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -1106,16 +1155,17 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+checksum = "93f50113171a713f4a4231ef82eb26703607139b35dcb56241f0ceab2ae1f7d8"
 dependencies = [
- "cfg-if",
+ "cpubits",
  "ecdsa",
  "elliptic-curve",
- "once_cell",
- "sha2 0.10.9",
+ "primeorder",
+ "sha2 0.11.0",
  "signature",
+ "wnaf",
 ]
 
 [[package]]
@@ -1270,14 +1320,15 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "p256"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primefield",
  "primeorder",
- "sha2 0.10.9",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -1293,7 +1344,7 @@ dependencies = [
  "p3-poseidon1",
  "p3-poseidon2",
  "p3-symmetric",
- "rand 0.10.1",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -1336,7 +1387,7 @@ dependencies = [
  "p3-maybe-rayon",
  "p3-util",
  "paste",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "tracing",
 ]
@@ -1354,7 +1405,7 @@ dependencies = [
  "p3-poseidon1",
  "p3-poseidon2",
  "p3-symmetric",
- "rand 0.10.1",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -1367,7 +1418,7 @@ dependencies = [
  "p3-field",
  "p3-maybe-rayon",
  "p3-util",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "tracing",
 ]
@@ -1388,7 +1439,7 @@ dependencies = [
  "p3-field",
  "p3-symmetric",
  "p3-util",
- "rand 0.10.1",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -1409,7 +1460,7 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "paste",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
 ]
 
@@ -1431,7 +1482,7 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "paste",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "spin",
  "tracing",
@@ -1446,7 +1497,7 @@ dependencies = [
  "p3-field",
  "p3-mds",
  "p3-symmetric",
- "rand 0.10.1",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -1459,7 +1510,7 @@ dependencies = [
  "p3-mds",
  "p3-symmetric",
  "p3-util",
- "rand 0.10.1",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -1490,7 +1541,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
- "group",
+ "group 0.13.0",
 ]
 
 [[package]]
@@ -1501,9 +1552,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -1516,9 +1567,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs8"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der",
  "spki",
@@ -1540,12 +1591,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "primeorder"
-version = "0.13.6"
+name = "primefield"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint",
+ "crypto-common 0.2.1",
+ "ff 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
 dependencies = [
  "elliptic-curve",
+ "once_cell",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -1576,6 +1645,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1587,17 +1662,18 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
+ "chacha20",
+ "getrandom",
  "rand_core 0.10.1",
 ]
 
@@ -1616,9 +1692,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
 
 [[package]]
 name = "rand_core"
@@ -1674,12 +1747,12 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
 dependencies = [
+ "crypto-bigint",
  "hmac",
- "subtle",
 ]
 
 [[package]]
@@ -1776,14 +1849,14 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct",
+ "ctutils",
  "der",
- "generic-array",
- "pkcs8",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -1856,6 +1929,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,13 +1961,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha3"
-version = "0.11.0"
+name = "shake"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
 dependencies = [
  "digest 0.11.3",
  "keccak",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -1895,12 +1979,12 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1920,9 +2004,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
  "der",
@@ -1964,12 +2048,12 @@ dependencies = [
  "p3-field",
  "p3-koala-bear",
  "p3-mersenne-31",
- "rand 0.8.6",
+ "rand 0.10.2",
  "risc0-zkp",
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "sha3",
+ "shake",
  "spongefish-derive",
  "zeroize",
 ]
@@ -2176,12 +2260,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,6 +2379,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ blake2 = "0.11.0-rc.5"
 blake3 = { version = "^1.8.4", features = ["traits-preview", "zeroize"] }
 bls12_381 = "^0.8.0"
 bytemuck = "^1.22"
-curve25519-dalek = "^4.1"
+curve25519-dalek = "^5.0"
 digest = "0.11.2"
 hashbrown = { version = "0.17.0", default-features = false, features = [
     "allocator-api2",
@@ -63,23 +63,23 @@ hashbrown = { version = "0.17.0", default-features = false, features = [
 hex = "0.4.3"
 itertools = { version = "0.15.0", features = ["use_alloc"], default-features = false }
 k12 = "0.5.0"
-k256 = "^0.13"
+k256 = "^0.14"
 keccak = "^0.2.0"
 libtest-mimic = "0.8.1"
-p256 = "^0.13"
+p256 = "^0.14"
 p3-baby-bear = "0.6"
 p3-field = "0.6"
 p3-koala-bear = "0.6"
 p3-mersenne-31 = "0.6"
 p3-poseidon2 = "0.6"
 p3-symmetric = "0.6"
-rand = "^0.8.5"
+rand = "^0.10.2"
 rayon = "^1.10.0"
 risc0-zkp = "3.0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.11.0"
-sha3 = "=0.11.0"
+shake = "0.1.0"
 spin = { version = "0.12", default-features = false, features = ["rwlock"] }
 # Intra-workspace dependencies
 spongefish = { version = "0.7.4", path = "spongefish" }

--- a/spongefish/Cargo.toml
+++ b/spongefish/Cargo.toml
@@ -23,7 +23,7 @@ derive = ["dep:spongefish-derive"]
 zeroize = ["dep:zeroize"]
 # Cryptographic hash function features
 sha2 = ["dep:sha2"]
-sha3 = ["dep:sha3"]
+sha3 = ["dep:shake"]
 blake2 = ["dep:blake2"]
 blake3 = ["dep:blake3"]
 k12 = ["dep:k12"]
@@ -73,10 +73,10 @@ p3-baby-bear = { workspace = true, optional = true }
 p3-field = { workspace = true, optional = true }
 p3-koala-bear = { workspace = true, optional = true }
 p3-mersenne-31 = { workspace = true, optional = true }
-rand = { workspace = true, features = ["getrandom"] }
+rand = { workspace = true, features = ["sys_rng"] }
 risc0-zkp = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
-sha3 = { workspace = true, optional = true }
+shake = { workspace = true, optional = true }
 spongefish-derive = { workspace = true, optional = true }
 zeroize = { workspace = true, features = ["zeroize_derive"], optional = true }
 
@@ -100,7 +100,6 @@ libtest-mimic = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
-sha3 = { workspace = true }
 
 [lints]
 workspace = true

--- a/spongefish/examples/bulletproof.rs
+++ b/spongefish/examples/bulletproof.rs
@@ -148,7 +148,6 @@ fn dot_prod(a: &[Scalar], b: &[Scalar]) -> Scalar {
 }
 
 fn main() {
-    let mut rng = rand::thread_rng();
     // the vector size
     let size = 8;
     // the testing vectors
@@ -161,12 +160,12 @@ fn main() {
     let ab = dot_prod(&a, &b);
     // the generators to be used for respectively a, b, ip
     let g = (0..a.len())
-        .map(|_| RistrettoPoint::random(&mut rng))
+        .map(|_| RistrettoPoint::from_uniform_bytes(&rand::random()))
         .collect::<Vec<_>>();
     let h = (0..b.len())
-        .map(|_| RistrettoPoint::random(&mut rng))
+        .map(|_| RistrettoPoint::from_uniform_bytes(&rand::random()))
         .collect::<Vec<_>>();
-    let u = RistrettoPoint::random(&mut rng);
+    let u = RistrettoPoint::from_uniform_bytes(&rand::random());
 
     let instance = Instance {
         ip_commitment: RistrettoPoint::multiscalar_mul(&a, &g)

--- a/spongefish/examples/schnorr.rs
+++ b/spongefish/examples/schnorr.rs
@@ -1,13 +1,34 @@
 /// Example: simple Schnorr proofs in <100 LOC
 use ark_ec::{CurveGroup, PrimeGroup};
 use ark_std::UniformRand;
-use rand::rngs::OsRng;
 use spongefish::{
     Codec, Encoding, NargDeserialize, NargSerialize, ProverState, VerificationError,
     VerificationResult, VerifierState,
 };
 
 struct Schnorr;
+
+/// Adapts rand 0.10's infallible RNG trait to arkworks' rand 0.8 trait.
+struct ArkRng<'a, R: ?Sized>(&'a mut R);
+
+impl<R: rand::Rng + ?Sized> ark_std::rand::RngCore for ArkRng<'_, R> {
+    fn next_u32(&mut self) -> u32 {
+        self.0.next_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0.next_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.0.fill_bytes(dest);
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), ark_std::rand::Error> {
+        self.0.fill_bytes(dest);
+        Ok(())
+    }
+}
 
 impl Schnorr {
     /// Here the proving algorithm takes as input a [`ProverState`], and an instance-witness pair.
@@ -29,7 +50,7 @@ impl Schnorr {
         G::ScalarField: Codec,
     {
         // `ProverState` types implement a cryptographically-secure random number generator.
-        let k = G::ScalarField::rand(prover_state.rng());
+        let k = G::ScalarField::rand(&mut ArkRng(prover_state.rng()));
         let K = instance[0] * k;
 
         prover_state.prover_message(&K);
@@ -70,7 +91,8 @@ fn main() {
 
     // Set up the elements to prove
     let generator = G::generator();
-    let sk = F::rand(&mut OsRng);
+    let mut rng: rand::rngs::StdRng = rand::make_rng();
+    let sk = F::rand(&mut ArkRng(&mut rng));
     let pk = generator * sk;
     let instance = [generator, pk];
 

--- a/spongefish/src/drivers/p256_impl.rs
+++ b/spongefish/src/drivers/p256_impl.rs
@@ -1,7 +1,7 @@
 //! p256 codec implementations
 
 use p256::{
-    elliptic_curve::{group::GroupEncoding, ops::Reduce, sec1::ToEncodedPoint, PrimeField},
+    elliptic_curve::{group::GroupEncoding, ops::Reduce, sec1::ToSec1Point, PrimeField},
     AffinePoint, ProjectivePoint, Scalar, U256,
 };
 
@@ -23,8 +23,8 @@ impl Decoding<[u8]> for Scalar {
     type Repr = Array64;
 
     fn decode(buf: Self::Repr) -> Self {
-        let mut hi = Self::reduce(U256::from_be_slice(&buf.0[0..32]));
-        let lo = Self::reduce(U256::from_be_slice(&buf.0[32..64]));
+        let mut hi = Self::reduce(&U256::from_be_slice(&buf.0[0..32]));
+        let lo = Self::reduce(&U256::from_be_slice(&buf.0[32..64]));
         for _ in 0..256 {
             hi += hi;
         }
@@ -76,12 +76,12 @@ impl Encoding<[u8]> for Scalar {
 // Implement Encoding for ProjectivePoint
 impl Encoding<[u8]> for ProjectivePoint {
     fn encode(&self) -> impl AsRef<[u8]> {
-        self.to_encoded_point(true)
+        self.to_sec1_point(true)
     }
 }
 
 impl Encoding<[u8]> for AffinePoint {
     fn encode(&self) -> impl AsRef<[u8]> {
-        self.to_encoded_point(true)
+        self.to_sec1_point(true)
     }
 }

--- a/spongefish/src/drivers/secp256k1_impl.rs
+++ b/spongefish/src/drivers/secp256k1_impl.rs
@@ -3,9 +3,9 @@ use k256::{
     elliptic_curve::{
         bigint::U512,
         ff::{Field, PrimeField},
-        sec1::{FromEncodedPoint, ToEncodedPoint},
+        sec1::{FromSec1Point, Sec1Point, ToSec1Point},
     },
-    AffinePoint, EncodedPoint, ProjectivePoint, Scalar,
+    AffinePoint, ProjectivePoint, Scalar, Secp256k1,
 };
 
 use crate::{
@@ -26,7 +26,7 @@ impl Decoding<[u8]> for Scalar {
 
     fn decode(buf: Self::Repr) -> Self {
         use k256::elliptic_curve::ops::Reduce;
-        Self::reduce(U512::from_be_slice(&buf.0))
+        Self::reduce(&U512::from_be_slice(&buf.0))
     }
 }
 
@@ -55,8 +55,9 @@ impl NargDeserialize for ProjectivePoint {
             return Err(VerificationError);
         }
 
-        let encoded = EncodedPoint::from_bytes(&buf[..33]).map_err(|_| VerificationError)?;
-        let point = Option::from(Self::from_encoded_point(&encoded)).ok_or(VerificationError)?;
+        let encoded =
+            Sec1Point::<Secp256k1>::from_bytes(&buf[..33]).map_err(|_| VerificationError)?;
+        let point = Option::from(Self::from_sec1_point(&encoded)).ok_or(VerificationError)?;
         *buf = &buf[33..];
         Ok(point)
     }
@@ -72,13 +73,13 @@ impl Encoding<[u8]> for Scalar {
 // Implement Encoding for ProjectivePoint
 impl Encoding<[u8]> for ProjectivePoint {
     fn encode(&self) -> impl AsRef<[u8]> {
-        self.to_affine().to_encoded_point(true)
+        self.to_affine().to_sec1_point(true)
     }
 }
 
 impl Encoding<[u8]> for AffinePoint {
     fn encode(&self) -> impl AsRef<[u8]> {
-        self.to_encoded_point(true)
+        self.to_sec1_point(true)
     }
 }
 
@@ -91,7 +92,7 @@ mod tests {
 
     #[test]
     fn test_scalar_serialize_deserialize() {
-        let scalar = Scalar::random(&mut rand::thread_rng());
+        let scalar = Scalar::random(&mut rand::rng());
 
         let mut buf = Vec::new();
         scalar.serialize_into_narg(&mut buf);
@@ -105,7 +106,7 @@ mod tests {
     fn test_point_serialize_deserialize() {
         use k256::elliptic_curve::Group;
 
-        let point = ProjectivePoint::random(&mut rand::thread_rng());
+        let point = ProjectivePoint::random(&mut rand::rng());
 
         let mut buf = Vec::new();
         point.serialize_into_narg(&mut buf);
@@ -117,7 +118,7 @@ mod tests {
 
     #[test]
     fn test_scalar_encoding() {
-        let scalar = Scalar::random(&mut rand::thread_rng());
+        let scalar = Scalar::random(&mut rand::rng());
 
         let encoded = scalar.encode();
         let encoded_bytes = encoded.as_ref();

--- a/spongefish/src/instantiations/mod.rs
+++ b/spongefish/src/instantiations/mod.rs
@@ -23,7 +23,7 @@ pub type Ascon12 = DuplexSponge<permutations::Ascon12, 40, 16>;
 
 #[cfg(feature = "sha3")]
 /// SHAKE-128's XOF used as a [`DuplexSpongeInterface`][`crate::DuplexSpongeInterface`].
-pub type Shake128 = xof::XOF<sha3::Shake128>;
+pub type Shake128 = xof::XOF<shake::Shake128>;
 
 /// KangarooTwelve (K12) - fast reduced-round Keccak variant.
 #[cfg(feature = "k12")]

--- a/spongefish/src/instantiations/tests.rs
+++ b/spongefish/src/instantiations/tests.rs
@@ -1,4 +1,4 @@
-use rand::RngCore;
+use rand::Rng;
 
 use crate::duplex_sponge::legacy::DigestBridge;
 use crate::permutations::keccak::Keccak;

--- a/spongefish/src/instantiations/xof.rs
+++ b/spongefish/src/instantiations/xof.rs
@@ -119,11 +119,11 @@ where
 }
 
 #[cfg(feature = "sha3")]
-impl XOF<sha3::Shake128> {
+impl XOF<shake::Shake128> {
     pub(crate) fn from_protocol_id(protocol_id: [u8; 64]) -> Self {
         const RATE: usize = 168;
 
-        let mut hasher = sha3::Shake128::default();
+        let mut hasher = shake::Shake128::default();
         let mut initial_block = [0u8; RATE];
         initial_block[..protocol_id.len()].copy_from_slice(&protocol_id);
         digest::Update::update(&mut hasher, &initial_block);
@@ -165,7 +165,7 @@ mod tests {
     #[cfg(feature = "sha3")]
     #[test]
     fn shake128_clone_preserves_squeeze_position() {
-        assert_clone_preserves_squeeze_position::<sha3::Shake128>();
+        assert_clone_preserves_squeeze_position::<shake::Shake128>();
     }
 
     #[cfg(feature = "k12")]

--- a/spongefish/src/lib.rs
+++ b/spongefish/src/lib.rs
@@ -127,7 +127,7 @@
 //! 2. [`Ascon12`][instantiations::Ascon12], the duplex sponge construction [[CO25], Section 3.3] for the
 //! [`ascon`] permutation [Ascon], used in overwrite mode.
 //! Available with the `ascon` feature flag;
-//! 3. [`Shake128`][instantiations::Shake128], based on the extensible output function [sha3::Shake128].
+//! 3. [`Shake128`][instantiations::Shake128], based on the extensible output function [shake::Shake128].
 //! Available with the `sha3` feature flag (enabled by default);
 //! 4. [`Blake3`][instantiations::Blake3], based on the extensible output function [blake3::Hasher].
 //! Available with the `sha3` feature flag (enabled by default);

--- a/spongefish/src/narg_prover.rs
+++ b/spongefish/src/narg_prover.rs
@@ -3,9 +3,9 @@ use core::fmt;
 #[cfg(not(feature = "sha3"))]
 use core::marker::PhantomData;
 
+use rand::{CryptoRng, Rng, SeedableRng};
 #[cfg(feature = "sha3")]
-use rand::Rng;
-use rand::{CryptoRng, RngCore, SeedableRng};
+use rand::{RngExt, TryCryptoRng, TryRng};
 
 #[cfg(feature = "sha3")]
 use crate::StdHash;
@@ -22,7 +22,7 @@ type PrivateRng<R> = PhantomData<R>;
 /// It provides the **secret coins** of the prover for zero-knowledge, and
 /// the hash function state for the verifier's **public coins**.
 ///
-/// The internal random number generator is instantiated with [`sha3::Shake128`],
+/// The internal random number generator is instantiated with [`shake::Shake128`],
 /// seeded via [`rand::rngs::StdRng`].
 ///
 /// # Safety
@@ -35,7 +35,7 @@ pub struct ProverState<
     R = StdRng,
 > where
     H: DuplexSpongeInterface,
-    R: RngCore + CryptoRng,
+    R: Rng + CryptoRng,
 {
     /// The randomness state of the prover.
     pub(crate) private_rng: PrivateRng<R>,
@@ -56,12 +56,12 @@ pub struct ProverState<
 ///
 /// For most public-coin protocols it is *vital* not to have two different verifier messages for the same prover message.
 /// For this reason, we construct an RNG that absorbs whatever the verifier absorbs, and that in addition
-/// is seeded by a cryptographic random number generator (by default, [`rand::rngs::OsRng`]).
+/// is seeded by a cryptographic random number generator.
 ///
 /// Every time a challenge is being generated, the private prover sponge is ratcheted, so that it can't be inverted and the randomness recovered.
 #[derive(Default)]
 #[cfg(feature = "sha3")]
-pub struct ReseedableRng<R: RngCore + CryptoRng> {
+pub struct ReseedableRng<R: Rng + CryptoRng> {
     /// The duplex sponge that is used to generate the prover's private random coins.
     pub(crate) duplex_sponge: StdHash,
     /// The cryptographic random number generator that seeds the sponge.
@@ -69,10 +69,10 @@ pub struct ReseedableRng<R: RngCore + CryptoRng> {
 }
 
 #[cfg(feature = "sha3")]
-impl<R: RngCore + CryptoRng> From<R> for ReseedableRng<R> {
+impl<R: Rng + CryptoRng> From<R> for ReseedableRng<R> {
     fn from(mut csrng: R) -> Self {
         let mut duplex_sponge = StdHash::default();
-        let seed: [u8; 32] = csrng.gen::<[u8; 32]>();
+        let seed: [u8; 32] = csrng.random();
         duplex_sponge.absorb(&seed);
         Self {
             duplex_sponge,
@@ -85,42 +85,40 @@ impl<R: RngCore + CryptoRng> From<R> for ReseedableRng<R> {
 impl ReseedableRng<StdRng> {
     /// Creates a reseedable RNG backed by `StdRng`.
     pub fn new() -> Self {
-        let csrng = StdRng::from_entropy();
+        let csrng: StdRng = rand::make_rng();
         csrng.into()
     }
 }
 
 #[cfg(feature = "sha3")]
-impl<R: RngCore + CryptoRng> RngCore for ReseedableRng<R> {
-    fn next_u32(&mut self) -> u32 {
+impl<R: Rng + CryptoRng> TryRng for ReseedableRng<R> {
+    type Error = core::convert::Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
         let mut buf = [0u8; 4];
-        self.fill_bytes(buf.as_mut());
-        u32::from_le_bytes(buf)
+        self.duplex_sponge.squeeze(buf.as_mut());
+        Ok(u32::from_le_bytes(buf))
     }
 
-    fn next_u64(&mut self) -> u64 {
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
         let mut buf = [0u8; 8];
-        self.fill_bytes(buf.as_mut());
-        u64::from_le_bytes(buf)
+        self.duplex_sponge.squeeze(buf.as_mut());
+        Ok(u64::from_le_bytes(buf))
     }
 
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
         // fill `dest` with the output of the sponge
         self.duplex_sponge.squeeze(dest);
         // xxx. for extra safety we can imagine ratcheting here so that
         // the state of the sponge can't be reverted after
         // erase the state from the sponge so that it can't be reverted
         // self.duplex_sponge.ratchet();
-    }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
-        self.duplex_sponge.squeeze(dest);
         Ok(())
     }
 }
 
 #[cfg(feature = "sha3")]
-impl<R: RngCore + CryptoRng> ReseedableRng<R> {
+impl<R: Rng + CryptoRng> ReseedableRng<R> {
     /// Reseeds the internal sponge with the provided bytes.
     pub fn reseed_with(&mut self, value: &[u8]) {
         self.duplex_sponge.ratchet();
@@ -130,18 +128,18 @@ impl<R: RngCore + CryptoRng> ReseedableRng<R> {
 
     /// Reseeds the internal sponge with fresh entropy from the CSRNG.
     pub fn reseed(&mut self) {
-        let seed = self.csrng.gen::<[u8; 32]>();
+        let seed = self.csrng.random::<[u8; 32]>();
         self.reseed_with(&seed);
     }
 }
 
 #[cfg(feature = "sha3")]
-impl<R: RngCore + CryptoRng> CryptoRng for ReseedableRng<R> {}
+impl<R: Rng + CryptoRng> TryCryptoRng for ReseedableRng<R> {}
 
 impl<H, R> fmt::Debug for ProverState<H, R>
 where
     H: DuplexSpongeInterface,
-    R: RngCore + CryptoRng,
+    R: Rng + CryptoRng,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "ProverState<{}>", core::any::type_name::<H>())
@@ -151,7 +149,7 @@ where
 impl<H, R> ProverState<H, R>
 where
     H: DuplexSpongeInterface,
-    R: RngCore + CryptoRng,
+    R: Rng + CryptoRng,
 {
     #[cfg(feature = "sha3")]
     /// Returns the reseedable RNG bound to this transcript.
@@ -285,21 +283,21 @@ where
     }
 }
 
-/// Creates a new [`ProverState`] seeded using [`rand::SeedableRng::from_entropy`].
+/// Creates a new [`ProverState`] seeded using [`rand::make_rng`].
 ///
 /// [`Default`] provides alternative initialization methods than the one via
 /// [`DomainSeparator`][`crate::DomainSeparator`].
 /// [`ProverState::default`] is only available with the `yolocrypto` feature and its support in
 /// future releases is not guaranteed.
 #[cfg(feature = "yolocrypto")]
-impl<H: DuplexSpongeInterface + Default, R: RngCore + CryptoRng + SeedableRng> Default
+impl<H: DuplexSpongeInterface + Default, R: Rng + CryptoRng + SeedableRng> Default
     for ProverState<H, R>
 {
     fn default() -> Self {
         Self {
             duplex_sponge_state: H::default(),
             #[cfg(feature = "sha3")]
-            private_rng: R::from_entropy().into(),
+            private_rng: rand::make_rng::<R>().into(),
             #[cfg(not(feature = "sha3"))]
             private_rng: PhantomData,
             narg_string: Vec::new(),
@@ -308,12 +306,12 @@ impl<H: DuplexSpongeInterface + Default, R: RngCore + CryptoRng + SeedableRng> D
 }
 
 /// Creates a new [`ProverState`] using the given duplex sponge interface.
-impl<H: DuplexSpongeInterface, R: RngCore + CryptoRng + SeedableRng> From<H> for ProverState<H, R> {
+impl<H: DuplexSpongeInterface, R: Rng + CryptoRng + SeedableRng> From<H> for ProverState<H, R> {
     fn from(value: H) -> Self {
         Self {
             duplex_sponge_state: value,
             #[cfg(feature = "sha3")]
-            private_rng: R::from_entropy().into(),
+            private_rng: rand::make_rng::<R>().into(),
             #[cfg(not(feature = "sha3"))]
             private_rng: PhantomData,
             narg_string: Vec::new(),

--- a/spongefish/src/tests.rs
+++ b/spongefish/src/tests.rs
@@ -1,7 +1,7 @@
 use alloc::string::String;
 
-use rand::RngCore;
-use sha3::digest::{ExtendableOutput, Update, XofReader};
+use rand::Rng;
+use shake::digest::{ExtendableOutput, Update, XofReader};
 
 use crate::{DuplexSpongeInterface, Encoding, NargDeserialize, VerificationError};
 
@@ -189,7 +189,7 @@ fn session_id_matches_rfc_construction() {
     let domain = b"fiat-shamir/session-id";
     initial_block[..domain.len()].copy_from_slice(domain);
 
-    let mut shake = sha3::Shake128::default();
+    let mut shake = shake::Shake128::default();
     shake.update(&initial_block);
     shake.update(b"discrete_logarithm");
     let mut reader = shake.finalize_xof();

--- a/spongefish/tests/test_spec.rs
+++ b/spongefish/tests/test_spec.rs
@@ -30,15 +30,15 @@ struct Operation {
 
 #[derive(Clone)]
 struct Shake128Spec {
-    hasher: sha3::Shake128,
+    hasher: shake::Shake128,
 }
 
 impl Shake128Spec {
     fn new(iv: [u8; 64]) -> Self {
-        use sha3::digest::Update;
+        use shake::digest::Update;
 
         const RATE: usize = 168;
-        let mut hasher = sha3::Shake128::default();
+        let mut hasher = shake::Shake128::default();
         let mut initial_block = [0u8; RATE];
         initial_block[..64].copy_from_slice(&iv);
         hasher.update(&initial_block);
@@ -50,13 +50,13 @@ impl DuplexSpongeInterface for Shake128Spec {
     type U = u8;
 
     fn absorb(&mut self, input: &[Self::U]) -> &mut Self {
-        use sha3::digest::Update;
+        use shake::digest::Update;
         self.hasher.update(input);
         self
     }
 
     fn squeeze(&mut self, output: &mut [Self::U]) -> &mut Self {
-        use sha3::digest::{ExtendableOutput, XofReader};
+        use shake::digest::{ExtendableOutput, XofReader};
         let mut reader = self.hasher.clone().finalize_xof();
         reader.read(output);
         self


### PR DESCRIPTION
This PR provides updates to interelated cryptography dependencies including `rand`, `curve25519-dalek`, `k256`, `p256`, `elliptic-curve`. `sha3` is replaced with the new `shake` crate.

This is a breaking change as downstream consumers of spongefish may be required to make the same updates.
