### PR TITLE
chore(circuit): remove unused p3-field dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1981,7 +1981,6 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.15.0",
  "p3-baby-bear",
- "p3-field",
  "spin",
  "spongefish",
 ]

--- a/circuit/Cargo.toml
+++ b/circuit/Cargo.toml
@@ -22,7 +22,6 @@ hashbrown = { workspace = true }
 itertools = { workspace = true }
 # Optional Plonky3/BabyBear support
 p3-baby-bear = { workspace = true, optional = true }
-p3-field = { workspace = true }
 spin = { workspace = true }
 spongefish = { workspace = true, features = ["derive"] }
 


### PR DESCRIPTION
## Summary

Remove the unused direct `p3-field` dependency from `spongefish-circuit` and update the lockfile accordingly.

## Why

The circuit crate does not reference `p3_field` directly. Its optional BabyBear integration uses `p3-baby-bear` and the corresponding `spongefish/p3-baby-bear` feature.

Keeping `p3-field` as an unconditional direct dependency adds an unnecessary dependency edge, particularly for `--no-default-features` builds. Default builds remain unaffected because `p3-baby-bear` already brings in `p3-field` transitively.

## Verification

- `cargo +stable check -p spongefish-circuit --all-targets`
- `cargo +stable check -p spongefish-circuit --all-targets --no-default-features`
- `cargo +stable test -p spongefish-circuit`
- `cargo +stable clippy -p spongefish-circuit --all-targets --no-default-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`