### PR TITLE
fix: update ascon to 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "ascon"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e716048a18530cce4684daf98a7563a499d710e1ed8ef35567fcb43a7c5f1"
+checksum = "f5a0543d9a0a29ecb1d2046beb7547e97941de03228a3f31e15addfc78836049"
 
 [[package]]
 name = "autocfg"

--- a/spongefish/Cargo.toml
+++ b/spongefish/Cargo.toml
@@ -53,7 +53,7 @@ ark-ec = { workspace = true, optional = true }
 # arkworks-rs
 ark-ff = { workspace = true, optional = true }
 ark-serialize = { workspace = true, optional = true }
-ascon = { version = "^0.4.0", optional = true }
+ascon = { version = "^0.5.0", optional = true }
 blake2 = { workspace = true, optional = true }
 blake3 = { workspace = true, optional = true }
 

--- a/spongefish/src/instantiations/permutations.rs
+++ b/spongefish/src/instantiations/permutations.rs
@@ -5,18 +5,87 @@ pub use keccak::KeccakF1600;
 
 #[cfg(feature = "ascon")]
 mod ascon {
-
-    #[derive(Clone, Debug, Default)]
-    pub struct Ascon12;
     use crate::duplex_sponge::Permutation;
 
-    impl Permutation<40> for Ascon12 {
+    const STATE_BYTES: usize = 40;
+    const WORD_BYTES: usize = 8;
+    const _: () = assert!(STATE_BYTES == core::mem::size_of::<ascon::State>());
+
+    /// Ascon permutation internal state: 5 64-bit words,
+    /// or equivalently 40 bytes in little-endian order.
+    #[derive(Clone, Debug, Default)]
+    pub struct Ascon12;
+
+    impl Permutation<STATE_BYTES> for Ascon12 {
         type U = u8;
 
-        fn permute(&self, state: &[u8; 40]) -> [u8; 40] {
-            let mut state = ascon::State::from(state);
-            state.permute_12();
-            state.as_bytes()
+        fn permute(&self, state: &[u8; STATE_BYTES]) -> [u8; STATE_BYTES] {
+            let mut new_state = *state;
+            self.permute_mut(&mut new_state);
+            new_state
+        }
+
+        fn permute_mut(&self, state: &mut [u8; STATE_BYTES]) {
+            let mut words = bytes_to_words(state);
+            ascon::permute12(&mut words);
+            words_to_bytes(&words, state);
+        }
+    }
+
+    fn bytes_to_words(state: &[u8; STATE_BYTES]) -> ascon::State {
+        core::array::from_fn(|i| {
+            let start = i * WORD_BYTES;
+            let mut word = [0; WORD_BYTES];
+            word.copy_from_slice(&state[start..start + WORD_BYTES]);
+            u64::from_le_bytes(word)
+        })
+    }
+
+    fn words_to_bytes(words: &ascon::State, state: &mut [u8; STATE_BYTES]) {
+        for (chunk, word) in state.as_chunks_mut::<WORD_BYTES>().0.iter_mut().zip(words) {
+            chunk.copy_from_slice(&word.to_le_bytes());
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        /// Serialize words in little-endian order, independently of the
+        /// conversion functions under test.
+        fn serialize_le(words: &ascon::State) -> [u8; STATE_BYTES] {
+            let mut bytes = [0u8; STATE_BYTES];
+            for (chunk, word) in bytes.chunks_exact_mut(WORD_BYTES).zip(words) {
+                chunk.copy_from_slice(&word.to_le_bytes());
+            }
+            bytes
+        }
+
+        /// Known-answer test for the permutation, using the word-level vectors
+        /// from the `ascon` crate's own test suite. Serializing the words with
+        /// an explicit byte order pins the state layout to little-endian
+        /// independently of the target's native endianness.
+        #[test]
+        fn ascon12_little_endian_known_answer() {
+            let input_words: ascon::State = [
+                0x0123_4567_89ab_cdef,
+                0xef01_2345_6789_abcd,
+                0xcdef_0123_4567_89ab,
+                0xabcd_ef01_2345_6789,
+                0x89ab_cdef_0123_4567,
+            ];
+            let output_words: ascon::State = [
+                0x2064_16df_c624_bb14,
+                0x1b0c_47a6_0105_8aab,
+                0x8934_cfc9_3814_cddd,
+                0xa973_8d28_7a74_8e4b,
+                0xddd9_34f0_58af_c7e1,
+            ];
+
+            let input = serialize_le(&input_words);
+            let expected = serialize_le(&output_words);
+
+            assert_eq!(Ascon12.permute(&input), expected);
         }
     }
 }

--- a/spongefish/src/instantiations/permutations.rs
+++ b/spongefish/src/instantiations/permutations.rs
@@ -55,7 +55,7 @@ mod ascon {
         /// conversion functions under test.
         fn serialize_le(words: &ascon::State) -> [u8; STATE_BYTES] {
             let mut bytes = [0u8; STATE_BYTES];
-            for (chunk, word) in bytes.chunks_exact_mut(WORD_BYTES).zip(words) {
+            for (chunk, word) in bytes.as_chunks_mut::<WORD_BYTES>().0.iter_mut().zip(words) {
                 chunk.copy_from_slice(&word.to_le_bytes());
             }
             bytes


### PR DESCRIPTION
ascon 0.5 removed the State struct's byte accessors (State::from(&[u8; 40]) and as_bytes); State is now a plain [u64; 5] and the permutation is exposed as free functions like permute12. The Ascon12 permutation now converts between bytes and words explicitly with u64::from_le_bytes/to_le_bytes, mirroring the KeccakF1600 module, and a known-answer test pins the little-endian state layout on any target. Supersedes #135 while preserving its little-endian byte-order handling, without the raw pointer copies.